### PR TITLE
fix: use sass-loader legacy api

### DIFF
--- a/config/webpack/loaders.js
+++ b/config/webpack/loaders.js
@@ -59,6 +59,7 @@ const CSSLoader = {
     {
       loader: 'sass-loader',
       options: {
+        api: 'legacy',
         sourceMap: true,
         sassOptions: {
           importer: globImporter(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@emulsify/core",
-  "version": "1.2.2",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@emulsify/core",
-      "version": "1.2.2",
+      "version": "1.3.1",
       "license": "GPL-2.0",
       "dependencies": {
         "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulsify/core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Bundled tooling for Storybook development + Webpack Build",
   "keywords": [
     "component library",


### PR DESCRIPTION
**This PR does the following:**
- Temporarily set sass-loader to legacy api until a more modern loader solution can be implemented