### PR TITLE
ProjectNameResolverPlugin

### DIFF
--- a/.storybook/custom-loader.js
+++ b/.storybook/custom-loader.js
@@ -1,0 +1,5 @@
+module.exports = function (source) {
+  const projectName = this.getOptions().projectName || '';
+  const result = source.replace(new RegExp(`${projectName}:`, 'g'), `${projectName}/`);
+  return result;
+};

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -53,7 +53,7 @@ module.exports = async ({ config }) => {
     test: /\.twig$/,
     use: [
       {
-        loader: path.resolve(__dirname, 'custom-loader.js'),
+        loader: path.resolve(__dirname, '../config/webpack/sdc-loader.js'),
         options: {
           projectName: emulsifyConfig.project.name,
         },

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -13,43 +13,31 @@ const emulsifyConfig = require('../../../../project.emulsify.json');
  */
 class ProjectNameResolverPlugin {
   constructor(options = {}) {
-    this.prefix = `${emulsifyConfig.project.name}:`; // Project name prefix.
+    this.prefix = options.projectName;
   }
-  apply(resolver) {
-    const target = resolver.ensureHook('resolved');
-    resolver
-      .getHook('resolve')
-      .tapAsync('ProjectNameResolverPlugin', (request, resolveContext, callback) => {
-        if (request.request.startsWith(this.prefix)) {
 
-          // Start - map request to @ aliases.
-          const file = resolves.TwigResolve.alias[request.request];
-          const srcStructure = file.split(`${emulsifyConfig.project.name}/src/`)[1];
-          const parentDir = srcStructure.split(`/`)[0];
-          const filePath = file.split(`/src/${parentDir}`)[1];
+  apply(resolver) {
+    const target = resolver.ensureHook('resolve');
+    resolver
+      .getHook('before-resolve')
+      .tapAsync('ProjectNameResolverPlugin', (request, resolveContext, callback) => {
+        const requestPath = request.request;
+
+        if (requestPath && requestPath.startsWith(`${this.prefix}:`)) {
+          const newRequestPath = requestPath.replace(`${this.prefix}:`, `${this.prefix}/`);
           const newRequest = {
             ...request,
-            request: `@${parentDir}${filePath}`,
+            request: newRequestPath,
           };
-          // End - map request to @ aliases.
 
-          // Change request to full file path.
-          // const newRequest = {
-          //   ...request,
-          //   request: resolves.TwigResolve.alias[request.request],
-          // };
-
-          // console.log(newRequest);
-
-          return resolver.doResolve(
+          resolver.doResolve(
             target,
             newRequest,
-            `Resolved ${this.prefix} URI: ${resolves.TwigResolve.alias[request.request]}`,
+            `Resolved ${this.prefix} URI: ${resolves.TwigResolve.alias[requestPath]}`,
             resolveContext,
             callback
           );
         } else {
-          // Proceed with default resolution if the custom prefix is not matched
           callback();
         }
       });
@@ -59,17 +47,23 @@ class ProjectNameResolverPlugin {
 module.exports = async ({ config }) => {
   // Alias
   Object.assign(config.resolve.alias, resolves.TwigResolve.alias);
-  config.resolve.plugins = [new ProjectNameResolverPlugin];
-  // console.log(config.resolve);
+
   // Twig
   config.module.rules.push({
     test: /\.twig$/,
     use: [
       {
+        loader: path.resolve(__dirname, 'custom-loader.js'),
+        options: {
+          projectName: emulsifyConfig.project.name,
+        },
+      },
+      {
         loader: 'twigjs-loader',
       },
     ],
   });
+
   // SCSS
   config.module.rules.push({
     test: /\.s[ac]ss$/i,
@@ -93,6 +87,13 @@ module.exports = async ({ config }) => {
     ],
   });
 
+  // YAML
+  config.module.rules.push({
+    test: /\.ya?ml$/,
+    loader: 'js-yaml-loader',
+  });
+
+  // Plugins
   config.plugins.push(
     new _StyleLintPlugin({
       configFile: path.resolve(__dirname, '../', '.stylelintrc.json'),
@@ -107,11 +108,12 @@ module.exports = async ({ config }) => {
     }),
   );
 
-  // YAML
-  config.module.rules.push({
-    test: /\.ya?ml$/,
-    loader: 'js-yaml-loader',
-  });
+  // Resolver Plugins
+  config.resolve.plugins = [
+    new ProjectNameResolverPlugin({
+      projectName: emulsifyConfig.project.name,
+    }),
+  ];
 
   return config;
 };

--- a/config/webpack/resolves.js
+++ b/config/webpack/resolves.js
@@ -42,7 +42,7 @@ function getAliases(aliasMatcher) {
     const fileName = path.basename(filePath);
 
     if (emulsifyConfig.project.platform === 'drupal') {
-      aliases[`${projectName}:${fileName.replace('.twig', '')}`] = file;
+      aliases[`${projectName}/${fileName.replace('.twig', '')}`] = file;
     }
   });
   // Add typical @namespace (path to directory) aliases for twig partials.

--- a/config/webpack/sdc-loader.js
+++ b/config/webpack/sdc-loader.js
@@ -1,5 +1,8 @@
 module.exports = function (source) {
   const projectName = this.getOptions().projectName || '';
-  const result = source.replace(new RegExp(`${projectName}:`, 'g'), `${projectName}/`);
+  const result = source.replace(
+    new RegExp(`${projectName}:`, 'g'),
+    `${projectName}/`,
+  );
   return result;
 };


### PR DESCRIPTION
**This PR does the following:**
- Adjusting the ProjectNameResolverPlugin.
- Removing colons from alias definitions.
- Add a custom loader for twig files.

### Notes:
- We might need to change the location of the custom loader, and we could think about renaming it.
- Both the plugin and the custom loader were needed to fix the new way of including templates inside other Twig templates.

`{% include "emulsify-ui-kit:placeholder" with { place_holder: "Placeholder Content" } %}`