### PR TITLE
fix: suppress unhelpful legacy JS-API deprecation warnings

### DIFF
--- a/config/webpack/loaders.js
+++ b/config/webpack/loaders.js
@@ -63,6 +63,7 @@ const CSSLoader = {
         sassOptions: {
           importer: globImporter(),
           outputStyle: 'compressed',
+          silenceDeprecations: ['legacy-js-api'],
         },
       },
     },

--- a/config/webpack/plugins.js
+++ b/config/webpack/plugins.js
@@ -30,7 +30,7 @@ const SpriteLoaderPlugin = new _SpriteLoaderPlugin({
 const ProgressPlugin = new webpack.ProgressPlugin();
 
 // Glob pattern for markup files.
-const componentFilesPattern = path.resolve(srcDir, '**/*.{twig,yml}');
+const componentFilesPattern = path.resolve(srcDir, '**/*.{twig,component.yml}');
 
 /**
  * Prepare list of twig files to copy to "compiled" directories.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@emulsify/core",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@emulsify/core",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "GPL-2.0",
       "dependencies": {
         "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulsify/core",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Bundled tooling for Storybook development + Webpack Build",
   "keywords": [
     "component library",


### PR DESCRIPTION
**This PR does the following:**
- suppress unhelpful legacy JS-API deprecation warnings
- Refine copy component file pattern

┆Issue is synchronized with this [Clickup task](https://app.clickup.com/t/86a4z76gr) by [Unito](https://www.unito.io)
