### PR TITLE
fix: a11y config compiling error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@emulsify/core",
-  "version": "2.6.1",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@emulsify/core",
-      "version": "2.6.1",
+      "version": "2.7.1",
       "license": "GPL-2.0",
       "dependencies": {
         "@babel/core": "^7.26.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emulsify/core",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Bundled tooling for Storybook development + Webpack Build",
   "keywords": [
     "component library",


### PR DESCRIPTION
**This PR does the following:**
- Publish version to npm is causing a11y compilation errors