### PR TITLE
fix: bypass the plugin’s internal “require by string” logic by importing each plugin

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -1,12 +1,18 @@
 // release.config.mjs
+import commitAnalyzer from '@semantic-release/commit-analyzer';
+import releaseNotes from '@semantic-release/release-notes-generator';
+import npm from '@semantic-release/npm';
+import github from '@semantic-release/github';
+
 export default {
   tagFormat: '${version}',
   branches: ['main'],
   repositoryUrl: 'git@github.com:emulsify-ds/emulsify-core.git',
   plugins: [
-    '@semantic-release/commit-analyzer',
-    '@semantic-release/release-notes-generator',
-    ['@semantic-release/npm', { npmPublish: false }],
-    '@semantic-release/github',
+    // explicit function + (optional) config object
+    [commitAnalyzer, { preset: 'angular' }],
+    [releaseNotes],
+    [npm, { npmPublish: false }],
+    [github],
   ],
 };


### PR DESCRIPTION
**This PR does the following:**
- bypass the plugin’s internal “require by string” logic by importing each plugin