### PR TITLE
fix: workaround for parserOpts not a function error during release

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "24.x"
       - name: Install

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -3,7 +3,16 @@ module.exports = {
   branches: ['main'],
   repositoryUrl: 'git@github.com:emulsify-ds/emulsify-core.git',
   plugins: [
-    '@semantic-release/commit-analyzer',
+    ['@semantic-release/commit-analyzer', {
+      preset: 'angular',
+      releaseRules: [
+        { type: 'feat', release: 'minor' },
+        { type: 'fix',  release: 'patch' }
+      ],
+      parserOpts: {
+        noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES']
+      }
+    }],
     '@semantic-release/release-notes-generator',
     ['@semantic-release/npm', { npmPublish: false }],
     '@semantic-release/github'


### PR DESCRIPTION
**This PR does the following:**
- fix: workaround for parserOpts not a function error during release