### PR TITLE
fix: workaround for parserOpts not a function error during release

### DIFF
--- a/release.config.cjs
+++ b/release.config.cjs
@@ -3,18 +3,28 @@ module.exports = {
   branches: ['main'],
   repositoryUrl: 'git@github.com:emulsify-ds/emulsify-core.git',
   plugins: [
-    ['@semantic-release/commit-analyzer', {
-      preset: 'angular',
-      releaseRules: [
-        { type: 'feat', release: 'minor' },
-        { type: 'fix',  release: 'patch' }
-      ],
-      parserOpts: {
-        noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES']
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        preset: 'angular',
+        parserOpts: {
+          noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES', 'BREAKING']
+        }
       }
-    }],
-    '@semantic-release/release-notes-generator',
+    ],
+    [
+      '@semantic-release/release-notes-generator',
+      {
+        preset: 'angular',
+        parserOpts: {
+          noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES', 'BREAKING']
+        },
+        writerOpts: {
+          commitsSort: ['subject', 'scope']
+        }
+      }
+    ],
     ['@semantic-release/npm', { npmPublish: false }],
     '@semantic-release/github'
   ]
-};
+}


### PR DESCRIPTION
**This PR does the following:**
- fix: workaround for parserOpts not a function error during release