### PR TITLE
fix: add twig boolval fallback

### DIFF
--- a/docs/migration-4x.md
+++ b/docs/migration-4x.md
@@ -183,6 +183,13 @@ Drupal-specific Twig filters are only loaded when the Drupal adapter enables the
 
 Core 4 no longer uses a browser-global Twig template store or patches `Twig.Templates` to resolve compiled Storybook dependencies. Each emitted Twig module now creates an isolated Twig.js factory instance and registers its own compiled dependency set locally. This keeps duplicate template IDs from colliding while avoiding global runtime cleanup during HMR.
 
+If Storybook reports `Twig.lib.boolval is not a function`, Twig.js failed while
+evaluating a boolean expression such as `{% if %}`, `and`, `or`, `not`, or a
+ternary. Core provides a narrow runtime fallback for that internal helper, but
+the message still usually points to dependency optimizer or transitive package
+drift. Clear Storybook/Vite caches and confirm the project-level `overrides`
+above are present in the consuming theme if the error appears during migration.
+
 ## Vituum Twig Integration
 
 Emulsify treats `@vituum/vite-plugin-twig` as a pinned integration point. The internal `vituum-patch.js` adapter removes Vituum build hooks that conflict with Emulsify's output model and fails fast if a future Vituum release changes the expected plugin shape, so projects should pin to a known-good Vituum version or update the adapter instead of accepting a silent rendering break.

--- a/src/extensions/twig/__tests__/register.test.js
+++ b/src/extensions/twig/__tests__/register.test.js
@@ -2,6 +2,8 @@
  * @file Tests for native Twig extension registration.
  */
 
+import TwigJs from 'twig';
+
 import { getTwigFunctionMap } from '../function-map.js';
 import { getTwigTagDefinitions } from '../tag-map.js';
 import { registerTwigExtensions } from '../register.js';
@@ -46,5 +48,62 @@ describe('registerTwigExtensions', () => {
     expect(() => registerTwigExtensions({})).toThrow(
       'A Twig.js instance with extendFunction(), extendTag(), and extend() is required.',
     );
+  });
+
+  it('adds a boolval fallback when Twig.js internals are missing it', () => {
+    const InternalTwig = {};
+    const Twig = {
+      extend: jest.fn((callback) => callback(InternalTwig)),
+      extendFunction: jest.fn(),
+      extendTag: jest.fn(),
+    };
+
+    registerTwigExtensions(Twig);
+
+    expect(typeof InternalTwig.lib.boolval).toBe('function');
+    expect(InternalTwig.lib.boolval(false)).toBe(false);
+    expect(InternalTwig.lib.boolval(0)).toBe(false);
+    expect(InternalTwig.lib.boolval('')).toBe(false);
+    expect(InternalTwig.lib.boolval('0')).toBe(false);
+    expect(InternalTwig.lib.boolval([])).toBe(false);
+    expect(InternalTwig.lib.boolval(null)).toBe(false);
+    expect(InternalTwig.lib.boolval(undefined)).toBe(false);
+    expect(InternalTwig.lib.boolval(true)).toBe(true);
+    expect(InternalTwig.lib.boolval(1)).toBe(true);
+    expect(InternalTwig.lib.boolval('false')).toBe(true);
+    expect(InternalTwig.lib.boolval([0])).toBe(true);
+  });
+
+  it('preserves Twig.js own boolval helper when present', () => {
+    const boolval = jest.fn(() => true);
+    const InternalTwig = {
+      lib: { boolval },
+    };
+    const Twig = {
+      extend: jest.fn((callback) => callback(InternalTwig)),
+      extendFunction: jest.fn(),
+      extendTag: jest.fn(),
+    };
+
+    registerTwigExtensions(Twig);
+
+    expect(InternalTwig.lib.boolval).toBe(boolval);
+  });
+
+  it('repairs a registered Twig.js instance before conditionals render', () => {
+    const twig = TwigJs.factory();
+
+    registerTwigExtensions(twig);
+    twig.extend((InternalTwig) => {
+      InternalTwig.lib.boolval = undefined;
+    });
+    registerTwigExtensions(twig);
+
+    const template = twig.twig({
+      data: '{% if value %}yes{% else %}no{% endif %}',
+    });
+
+    expect(template.render({ value: '0' })).toBe('no');
+    expect(template.render({ value: 'ready' })).toBe('yes');
   });
 });

--- a/src/extensions/twig/register.js
+++ b/src/extensions/twig/register.js
@@ -14,6 +14,47 @@ import { getTwigTagDefinitions } from './tag-map.js';
 const registeredTwigInstances = new WeakSet();
 
 /**
+ * PHP-style boolean conversion used by Twig.js truthiness checks.
+ *
+ * Twig.js normally provides this through `Twig.lib.boolval`, but dependency
+ * optimizer interop can drop the helper while leaving the rest of Twig usable.
+ *
+ * @param {*} value - Value to coerce using PHP/Twig truthiness rules.
+ * @returns {boolean} TRUE when the value should be truthy in Twig.
+ */
+function phpBoolval(value) {
+  return (
+    value !== false &&
+    value !== 0 &&
+    value !== '' &&
+    value !== '0' &&
+    !(Array.isArray(value) && value.length === 0) &&
+    value !== null &&
+    typeof value !== 'undefined'
+  );
+}
+
+/**
+ * Ensure Twig.js has the internal boolean helper required by conditionals.
+ *
+ * @param {Object} Twig - Twig.js module or compatible extension target.
+ * @returns {Object} The same Twig instance after compatibility patching.
+ */
+function ensureTwigBoolval(Twig) {
+  Twig.extend((InternalTwig) => {
+    if (!InternalTwig.lib) {
+      InternalTwig.lib = {};
+    }
+
+    if (typeof InternalTwig.lib.boolval !== 'function') {
+      InternalTwig.lib.boolval = phpBoolval;
+    }
+  });
+
+  return Twig;
+}
+
+/**
  * Register native Emulsify Twig functions and logic tags with Twig.js.
  *
  * @param {Object} Twig - Twig.js module or compatible extension target.
@@ -31,6 +72,8 @@ export function registerTwigExtensions(Twig) {
       'A Twig.js instance with extendFunction(), extendTag(), and extend() is required.',
     );
   }
+
+  ensureTwigBoolval(Twig);
 
   if (registeredTwigInstances.has(Twig)) {
     return Twig;


### PR DESCRIPTION
**This PR does the following:**

- Adds a narrow Twig.js compatibility fallback for `Twig.lib.boolval` when dependency optimizer or transitive package interop leaves the helper undefined.
- Preserves Twig.js’ native `boolval` implementation when it already exists.
- Adds regression coverage for missing `boolval`, including a real Twig conditional render.
- Documents the `Twig.lib.boolval is not a function` migration troubleshooting case.

### Related Issue(s)

- N/A

### Notes:

- This fallback only patches the missing internal helper. It does not override a valid Twig.js-provided `boolval`.
- The migration note still recommends clearing Storybook/Vite caches and confirming project-level dependency overrides because the error usually points to package or optimizer drift.

### Functional Testing:

- [ ] Run `npm run test -- src/extensions/twig/__tests__/register.test.js --runInBand`
- [ ] Run targeted ESLint against the touched Twig registration files
- [ ] Run targeted Prettier against the touched files
- [ ] Confirm pre-commit full lint and Prettier checks complete with no errors

### Security

No new user input handling or external execution paths are introduced. The change only fills a missing internal Twig.js boolean coercion helper.

### Accessibility

No accessibility review needed. This change does not alter rendered markup, styles, or interactive behavior except allowing existing Twig conditionals to render successfully.