### PR TITLE
fix: create a proper asset reference path for storybook-build

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -71,6 +71,27 @@ const _filename = fileURLToPath(import.meta.url);
 const _dirname = path.dirname(_filename);
 
 /**
+ * The consuming project root for Storybook static mounts.
+ *
+ * Storybook loads this package config from different physical locations
+ * depending on whether Core is linked locally or installed in node_modules, so
+ * static paths must be rooted at the process cwd rather than this file.
+ *
+ * @type {string}
+ */
+const projectRoot = process.cwd();
+
+/**
+ * Vite-generated Storybook chunks should not share `/assets` with project
+ * static files. Storybook copies staticDirs while the preview build runs, so
+ * keeping generated chunks in a separate folder avoids concurrent writers in
+ * `.out/assets`.
+ *
+ * @type {string}
+ */
+const storybookViteAssetsDir = 'storybook-assets';
+
+/**
  * Reads an optional HTML fragment relative to this config file.
  *
  * Missing files are treated as empty content so downstream projects can opt in
@@ -247,10 +268,17 @@ const baseConfig = {
   staticDirs: [
     ...existingStaticDirs([
       {
-        from: path.resolve(process.cwd(), 'assets'),
+        from: path.resolve(projectRoot, 'assets'),
         to: '/assets',
       },
-      path.resolve(process.cwd(), 'dist'),
+      {
+        from: path.resolve(projectRoot, 'dist/assets'),
+        to: '/assets',
+      },
+      {
+        from: path.resolve(projectRoot, 'dist'),
+        to: '/dist',
+      },
     ]),
   ],
 
@@ -452,6 +480,7 @@ const baseConfig = {
     const { mergeConfig } = await import('vite');
     /** @type {StorybookEnvironment} */
     const env = resolvedStorybookEnv;
+    const storybookBuildConfig = config?.build || {};
 
     // Keep using the `serve` branch of the shared Vite config here. Storybook
     // has historically consumed that branch, while `mode` still reflects
@@ -560,6 +589,14 @@ const baseConfig = {
 
     return {
       ...mergedConfig,
+      build: {
+        ...(mergedConfig.build || {}),
+        ...(storybookBuildConfig.outDir
+          ? { outDir: storybookBuildConfig.outDir }
+          : {}),
+        assetsDir: storybookViteAssetsDir,
+        emptyOutDir: false,
+      },
       resolve: mergeReactSingletonResolve(mergedConfig),
       optimizeDeps: {
         ...(mergedConfig.optimizeDeps || {}),

--- a/.storybook/main.test.js
+++ b/.storybook/main.test.js
@@ -3,6 +3,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
+
 describe('Storybook main config', () => {
   it('serves project root assets at the /assets URL prefix', () => {
     const script = `
@@ -24,6 +25,83 @@ describe('Storybook main config', () => {
       from: expectedFrom,
       to: '/assets',
     });
+  });
+
+  it('serves compiled dist assets without mounting all dist files at the output root', () => {
+    const script = `
+      const { mkdirSync, mkdtempSync } = await import('node:fs');
+      const { tmpdir } = await import('node:os');
+      const path = await import('node:path');
+      const { pathToFileURL } = await import('node:url');
+
+      const repoRoot = process.cwd();
+      const projectRoot = mkdtempSync(path.join(tmpdir(), 'emulsify-storybook-'));
+      mkdirSync(path.join(projectRoot, 'assets'), { recursive: true });
+      mkdirSync(path.join(projectRoot, 'dist/assets'), { recursive: true });
+      mkdirSync(path.join(projectRoot, 'dist/storybook'), { recursive: true });
+      process.chdir(projectRoot);
+
+      const { default: config } = await import(
+        pathToFileURL(path.join(repoRoot, '.storybook/main.js')).href
+      );
+
+      console.log(JSON.stringify({
+        staticDirs: config.staticDirs,
+        projectRoot: process.cwd(),
+      }));
+    `;
+    const output = execFileSync(process.execPath, [
+      '--input-type=module',
+      '--eval',
+      script,
+    ]);
+    const { staticDirs, projectRoot } = JSON.parse(output.toString());
+
+    expect(staticDirs).toEqual([
+      {
+        from: `${projectRoot}/assets`,
+        to: '/assets',
+      },
+      {
+        from: `${projectRoot}/dist/assets`,
+        to: '/assets',
+      },
+      {
+        from: `${projectRoot}/dist`,
+        to: '/dist',
+      },
+    ]);
+  });
+
+  it('keeps Storybook preview build assets separate from static /assets', async () => {
+    const script = `
+      const { default: config } = await import('./.storybook/main.js');
+      const finalConfig = await config.viteFinal({
+        mode: 'production',
+        build: {
+          outDir: '.out',
+          assetsDir: 'assets',
+          emptyOutDir: false,
+        },
+        server: {
+          fs: {
+            allow: [],
+          },
+        },
+        optimizeDeps: {},
+      });
+      console.log(JSON.stringify(finalConfig.build));
+    `;
+    const output = execFileSync(process.execPath, [
+      '--input-type=module',
+      '--eval',
+      script,
+    ]);
+    const build = JSON.parse(output.toString());
+
+    expect(build.outDir).toBe('.out');
+    expect(build.assetsDir).toBe('storybook-assets');
+    expect(build.emptyOutDir).toBe(false);
   });
 
   it('dedupes React runtime modules in the final Vite config', async () => {

--- a/scripts/release-fixtures.js
+++ b/scripts/release-fixtures.js
@@ -106,10 +106,10 @@ const releaseFixtures = [
     name: 'mixed-storybook',
     type: 'storybook',
     assert: ['.out/iframe.html'],
-    match: ['.out/assets/card.stories-*.js'],
+    match: ['.out/storybook-assets/card.stories-*.js'],
     assertContent: [
       {
-        pattern: '.out/assets/card.stories-*.js',
+        pattern: '.out/storybook-assets/card.stories-*.js',
         strings: ['Twig fixture', 'React fixture'],
       },
     ],
@@ -119,7 +119,7 @@ const releaseFixtures = [
     type: 'storybook',
     setup: setupLargeTwigStorybookFixture,
     assert: ['.out/iframe.html'],
-    match: ['.out/assets/gallery.stories-*.js'],
+    match: ['.out/storybook-assets/gallery.stories-*.js'],
     measure: true,
     metricComponentCount: largeTwigComponentCount,
   },


### PR DESCRIPTION
**This PR does the following:**

- Fixes `storybook-build` asset handling by resolving static directories from the consuming project root, whether `@emulsify/core` is linked locally or installed from `node_modules`.
- Mounts project `assets` and compiled `dist/assets` files at `/assets`.
- Mounts the remaining `dist` output at `/dist` instead of copying it to the Storybook output root.
- Writes Vite-generated Storybook chunks to `storybook-assets`, preventing them from sharing `.out/assets` with copied static files.
- Preserves Storybook’s configured output directory and prevents Vite from clearing it while static files are copied.
- Adds regression tests and updates the release fixtures for the new generated asset path.

### Related Issue(s)

- N/A

### Notes:

- Existing project asset references under `/assets` remain unchanged.
- Generated Storybook chunks move from `.out/assets` to `.out/storybook-assets`.
- Files outside `dist/assets` are now available under `/dist` rather than at the Storybook output root.

### Functional Testing:

- [ ] Run `npm run test -- .storybook/main.test.js --runInBand`
- [ ] Run `npm run fixtures:release`
- [ ] Run `npm run lint`
- [ ] Run `npm run storybook-build` in a consuming project.
- [ ] Confirm generated story chunks are written to `.out/storybook-assets`.
- [ ] Confirm files from `assets` and `dist/assets` resolve under `/assets`.
- [ ] Confirm other compiled files from `dist` resolve under `/dist`.

### Security

No new user input handling or external execution paths are introduced. This change only updates Storybook and Vite build paths.

### Accessibility

No accessibility review is needed. This change does not alter rendered markup, styles, or interactive behavior.