### PR TITLE
chore

### DIFF
--- a/.cli/init.js
+++ b/.cli/init.js
@@ -7,7 +7,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import yaml from 'js-yaml';
+import { dump as dumpYaml, load as loadYaml } from 'js-yaml';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -116,8 +116,8 @@ const applyToYmlFile = (filePath, functor) => {
     return;
   }
 
-  const file = yaml.load(fs.readFileSync(filePath, 'utf8'));
-  fs.writeFileSync(filePath, yaml.dump(functor(file)));
+  const file = loadYaml(fs.readFileSync(filePath, 'utf8'));
+  fs.writeFileSync(filePath, dumpYaml(functor(file)));
 };
 
 const main = () => {

--- a/.storybook/_drupal.js
+++ b/.storybook/_drupal.js
@@ -65,7 +65,6 @@ function mergeDrupalSettings(defaults, overrides) {
 
   for (const [key, value] of Object.entries(overrides || {})) {
     // Drupal settings keys are project/module-defined by design.
-    // eslint-disable-next-line security/detect-object-injection
     const defaultValue = merged[key];
     const nextValue =
       isPlainObject(defaultValue) && isPlainObject(value)
@@ -73,7 +72,6 @@ function mergeDrupalSettings(defaults, overrides) {
         : value;
 
     // Drupal settings keys are project/module-defined by design.
-    // eslint-disable-next-line security/detect-object-injection
     merged[key] = nextValue;
   }
 
@@ -156,7 +154,6 @@ window.drupalSettings = mergeDrupalSettings(
     // Attach each registered behavior while isolating individual failures.
     Object.keys(behaviors).forEach(function (behaviorName) {
       // Drupal behavior names are project/module-defined by design.
-      // eslint-disable-next-line security/detect-object-injection
       const behavior = behaviors[behaviorName];
       if (typeof behavior.attach === 'function') {
         try {

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -71,6 +71,27 @@ const _filename = fileURLToPath(import.meta.url);
 const _dirname = path.dirname(_filename);
 
 /**
+ * The consuming project root for Storybook static mounts.
+ *
+ * Storybook loads this package config from different physical locations
+ * depending on whether Core is linked locally or installed in node_modules, so
+ * static paths must be rooted at the process cwd rather than this file.
+ *
+ * @type {string}
+ */
+const projectRoot = process.cwd();
+
+/**
+ * Vite-generated Storybook chunks should not share `/assets` with project
+ * static files. Storybook copies staticDirs while the preview build runs, so
+ * keeping generated chunks in a separate folder avoids concurrent writers in
+ * `.out/assets`.
+ *
+ * @type {string}
+ */
+const storybookViteAssetsDir = 'storybook-assets';
+
+/**
  * Reads an optional HTML fragment relative to this config file.
  *
  * Missing files are treated as empty content so downstream projects can opt in
@@ -247,10 +268,17 @@ const baseConfig = {
   staticDirs: [
     ...existingStaticDirs([
       {
-        from: path.resolve(process.cwd(), 'assets'),
+        from: path.resolve(projectRoot, 'assets'),
         to: '/assets',
       },
-      path.resolve(process.cwd(), 'dist'),
+      {
+        from: path.resolve(projectRoot, 'dist/assets'),
+        to: '/assets',
+      },
+      {
+        from: path.resolve(projectRoot, 'dist'),
+        to: '/dist',
+      },
     ]),
   ],
 
@@ -452,6 +480,7 @@ const baseConfig = {
     const { mergeConfig } = await import('vite');
     /** @type {StorybookEnvironment} */
     const env = resolvedStorybookEnv;
+    const storybookBuildConfig = config?.build || {};
 
     // Keep using the `serve` branch of the shared Vite config here. Storybook
     // has historically consumed that branch, while `mode` still reflects
@@ -560,6 +589,14 @@ const baseConfig = {
 
     return {
       ...mergedConfig,
+      build: {
+        ...(mergedConfig.build || {}),
+        ...(storybookBuildConfig.outDir
+          ? { outDir: storybookBuildConfig.outDir }
+          : {}),
+        assetsDir: storybookViteAssetsDir,
+        emptyOutDir: false,
+      },
       resolve: mergeReactSingletonResolve(mergedConfig),
       optimizeDeps: {
         ...(mergedConfig.optimizeDeps || {}),

--- a/.storybook/main.test.js
+++ b/.storybook/main.test.js
@@ -3,6 +3,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
+
 describe('Storybook main config', () => {
   it('serves project root assets at the /assets URL prefix', () => {
     const script = `
@@ -24,6 +25,83 @@ describe('Storybook main config', () => {
       from: expectedFrom,
       to: '/assets',
     });
+  });
+
+  it('serves compiled dist assets without mounting all dist files at the output root', () => {
+    const script = `
+      const { mkdirSync, mkdtempSync } = await import('node:fs');
+      const { tmpdir } = await import('node:os');
+      const path = await import('node:path');
+      const { pathToFileURL } = await import('node:url');
+
+      const repoRoot = process.cwd();
+      const projectRoot = mkdtempSync(path.join(tmpdir(), 'emulsify-storybook-'));
+      mkdirSync(path.join(projectRoot, 'assets'), { recursive: true });
+      mkdirSync(path.join(projectRoot, 'dist/assets'), { recursive: true });
+      mkdirSync(path.join(projectRoot, 'dist/storybook'), { recursive: true });
+      process.chdir(projectRoot);
+
+      const { default: config } = await import(
+        pathToFileURL(path.join(repoRoot, '.storybook/main.js')).href
+      );
+
+      console.log(JSON.stringify({
+        staticDirs: config.staticDirs,
+        projectRoot: process.cwd(),
+      }));
+    `;
+    const output = execFileSync(process.execPath, [
+      '--input-type=module',
+      '--eval',
+      script,
+    ]);
+    const { staticDirs, projectRoot } = JSON.parse(output.toString());
+
+    expect(staticDirs).toEqual([
+      {
+        from: `${projectRoot}/assets`,
+        to: '/assets',
+      },
+      {
+        from: `${projectRoot}/dist/assets`,
+        to: '/assets',
+      },
+      {
+        from: `${projectRoot}/dist`,
+        to: '/dist',
+      },
+    ]);
+  });
+
+  it('keeps Storybook preview build assets separate from static /assets', async () => {
+    const script = `
+      const { default: config } = await import('./.storybook/main.js');
+      const finalConfig = await config.viteFinal({
+        mode: 'production',
+        build: {
+          outDir: '.out',
+          assetsDir: 'assets',
+          emptyOutDir: false,
+        },
+        server: {
+          fs: {
+            allow: [],
+          },
+        },
+        optimizeDeps: {},
+      });
+      console.log(JSON.stringify(finalConfig.build));
+    `;
+    const output = execFileSync(process.execPath, [
+      '--input-type=module',
+      '--eval',
+      script,
+    ]);
+    const build = JSON.parse(output.toString());
+
+    expect(build.outDir).toBe('.out');
+    expect(build.assetsDir).toBe('storybook-assets');
+    expect(build.emptyOutDir).toBe(false);
   });
 
   it('dedupes React runtime modules in the final Vite config', async () => {

--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -41,9 +41,15 @@ export default [
     ignores: ['**/*.min.js', '**/node_modules/**/*'],
 
     rules: {
-      // Keep historical project conventions while warning on risky patterns.
+      // Keep historical project conventions while tuning noisy security
+      // heuristics that flag intentional file-generation and source-scanning
+      // patterns throughout this tooling package.
       strict: 0,
       'consistent-return': 'off',
+      'security/detect-non-literal-fs-filename': 'off',
+      'security/detect-non-literal-regexp': 'off',
+      'security/detect-object-injection': 'off',
+      'security/detect-unsafe-regex': 'off',
       'no-underscore-dangle': 'off',
       'max-nested-callbacks': ['warn', 3],
       'import/extensions': 'off',

--- a/config/package-exports.test.js
+++ b/config/package-exports.test.js
@@ -101,6 +101,13 @@ function dryRunPackFiles() {
   return pack.files.map(({ path: filePath }) => normalizePackagePath(filePath));
 }
 
+function matchesForbiddenPackagePath(filePath, prefixes, suffixes) {
+  return (
+    prefixes.some((prefix) => filePath.startsWith(prefix)) ||
+    suffixes.some((suffix) => filePath.endsWith(suffix))
+  );
+}
+
 describe('@emulsify/core package exports', () => {
   it('imports each public export with native Node ESM resolution', () => {
     const checks = [
@@ -178,7 +185,6 @@ describe('@emulsify/core package exports', () => {
     const missingImports = [];
 
     for (const filePath of packageJsFiles) {
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
       const source = readFileSync(join(packageRoot, filePath), 'utf8');
 
       for (const specifier of collectRelativeJsSpecifiers(source)) {
@@ -248,10 +254,12 @@ describe('@emulsify/core package exports', () => {
       expect(packFileSet.has(filePath)).toBe(false);
     }
 
-    const accidentalFiles = packFiles.filter(
-      (filePath) =>
-        forbiddenPrefixes.some((prefix) => filePath.startsWith(prefix)) ||
-        forbiddenSuffixes.some((suffix) => filePath.endsWith(suffix)),
+    const accidentalFiles = packFiles.filter((filePath) =>
+      matchesForbiddenPackagePath(
+        filePath,
+        forbiddenPrefixes,
+        forbiddenSuffixes,
+      ),
     );
 
     expect(accidentalFiles).toEqual([]);

--- a/config/vite/entries.js
+++ b/config/vite/entries.js
@@ -57,7 +57,7 @@ export const sanitizePath = (s) => s.replace(/[^a-zA-Z0-9/_-]/g, '');
 function safeSetKey(map, key, value) {
   const forbidden = ['__proto__', 'prototype', 'constructor'];
   if (!key || forbidden.some((bad) => key.includes(bad))) return;
-  map[key] = value; // eslint-disable-line security/detect-object-injection
+  map[key] = value;
 }
 
 /** Return an absolute path from a source index entry or string. */

--- a/config/vite/plugins/mirror-components.js
+++ b/config/vite/plugins/mirror-components.js
@@ -68,7 +68,6 @@ const pruneEmptyDirsUpTo = (startDir, stopAtDir) => {
 
   const isEmpty = (dir) => {
     try {
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
       return readdirSync(dir).length === 0;
     } catch {
       return false;
@@ -79,7 +78,6 @@ const pruneEmptyDirsUpTo = (startDir, stopAtDir) => {
     if (!isEmpty(cursor)) break;
 
     try {
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
       rmdirSync(cursor);
     } catch {
       // Stop at the first directory that cannot be removed.
@@ -103,9 +101,7 @@ const pruneEmptyDirsUpTo = (startDir, stopAtDir) => {
  */
 export const filesHaveSameBytes = (sourceFile, destinationFile) => {
   try {
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
     const sourceStats = statSync(sourceFile);
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
     const destinationStats = statSync(destinationFile);
     if (!destinationStats.isFile()) return false;
     if (sourceStats.size !== destinationStats.size) return false;
@@ -117,10 +113,8 @@ export const filesHaveSameBytes = (sourceFile, destinationFile) => {
 
     const sourceBuffer = Buffer.allocUnsafe(FILE_COMPARE_CHUNK_SIZE);
     const destinationBuffer = Buffer.allocUnsafe(FILE_COMPARE_CHUNK_SIZE);
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
     const sourceHandle = openSync(sourceFile, 'r');
     try {
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
       const destinationHandle = openSync(destinationFile, 'r');
       try {
         let position = 0;
@@ -175,7 +169,6 @@ export const filesHaveSameBytes = (sourceFile, destinationFile) => {
  */
 const isSymlink = (filePath) => {
   try {
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
     return lstatSync(filePath).isSymbolicLink();
   } catch {
     return false;
@@ -189,7 +182,6 @@ const isSymlink = (filePath) => {
  */
 const removeSourceFile = (sourceFile) => {
   try {
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
     unlinkSync(sourceFile);
   } catch (error) {
     if (error?.code !== 'ENOENT') throw error;
@@ -221,12 +213,10 @@ const copyFileIntoPlace = (sourceFile, destinationFile) => {
 
   try {
     copyFileSync(sourceFile, tempDestination);
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
     renameSync(tempDestination, destinationFile);
     removeSourceFile(sourceFile);
   } catch (error) {
     try {
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
       unlinkSync(tempDestination);
     } catch {
       /* noop */
@@ -255,7 +245,6 @@ const moveFileIntoPlace = (sourceFile, destinationFile) => {
   }
 
   try {
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
     renameSync(sourceFile, destinationFile);
   } catch (error) {
     if (error?.code !== 'EXDEV') throw error;
@@ -282,7 +271,6 @@ const readMirrorState = (markerFile) => {
  */
 const writeMirrorState = (markerFile, state) => {
   mkdirSync(dirname(markerFile), { recursive: true });
-  // eslint-disable-next-line security/detect-non-literal-fs-filename
   writeFileSync(markerFile, `${JSON.stringify(state, null, 2)}\n`);
 };
 

--- a/config/vite/plugins/source-file-index.js
+++ b/config/vite/plugins/source-file-index.js
@@ -43,7 +43,6 @@ export function walkFiles(
 
     let entryNames = [];
     try {
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
       entryNames = readdirSync(currentDir, { withFileTypes: true }).sort(
         (a, b) => a.name.localeCompare(b.name),
       );

--- a/config/vite/plugins/svg-sprite.js
+++ b/config/vite/plugins/svg-sprite.js
@@ -82,7 +82,6 @@ export function svgSpriteFilePlugin({ include, symbolId = '[name]' }) {
         .map((abs) => {
           let content = '';
           try {
-            // eslint-disable-next-line security/detect-non-literal-fs-filename
             content = readFileSync(abs, 'utf8');
           } catch {
             return '';

--- a/config/vite/plugins/twig-module.js
+++ b/config/vite/plugins/twig-module.js
@@ -332,7 +332,6 @@ const buildTemplateFileCandidates = (baseDir, templatePath) => {
 const findExistingTemplateFile = (paths) =>
   paths.filter(Boolean).find((filePath) => {
     try {
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
       return fs.statSync(filePath).isFile();
     } catch {
       return false;
@@ -503,7 +502,6 @@ const parseTwigNamespaceReference = (templatePath, namespaces = {}) => {
     return {
       namespace: slashNamespace,
       // Namespace names come from the normalized Twig namespace map.
-      // eslint-disable-next-line security/detect-object-injection
       root: namespaces[slashNamespace],
       path: templatePath.slice(slashNamespace.length + 1),
     };
@@ -523,7 +521,6 @@ const componentGroupRoots = (componentRoot) => {
 
   try {
     // Component group roots come from a configured project directory.
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
     return fs
       .readdirSync(componentRoot, { withFileTypes: true })
       .filter((entry) => entry.isDirectory())
@@ -707,7 +704,6 @@ const invalidateKnownResolutionCacheEntries = (filePath) => {
 const compileTwigTemplate = (filePath, options, cache = compileCache) => {
   const absoluteFilePath = resolve(filePath);
   knownTwigFiles.add(absoluteFilePath);
-  // eslint-disable-next-line security/detect-non-literal-fs-filename
   const { mtimeMs } = fs.statSync(absoluteFilePath);
   const cached = cache.get(absoluteFilePath);
   if (cached?.mtimeMs === mtimeMs) {
@@ -718,7 +714,6 @@ const compileTwigTemplate = (filePath, options, cache = compileCache) => {
   registerTwigExtensions(compilerTwig);
   registerConfiguredTwigExtensions(compilerTwig, options);
 
-  // eslint-disable-next-line security/detect-non-literal-fs-filename
   const source = fs.readFileSync(absoluteFilePath, 'utf8');
   const compileOptions = {
     allowInlineIncludes: true,
@@ -1070,7 +1065,6 @@ export function emulsifyTwigModulePlugin(options) {
           const absoluteSourcePath = resolve(sourcePath);
           addDependencyImporter(absoluteSourcePath, sourceFilePath);
           this.addWatchFile(absoluteSourcePath);
-          // eslint-disable-next-line security/detect-non-literal-fs-filename
           const sourceText = fs.readFileSync(absoluteSourcePath, 'utf8');
 
           return unique([

--- a/package-lock.json
+++ b/package-lock.json
@@ -6000,9 +6000,9 @@
       }
     },
     "node_modules/@storybook/addon-themes": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.4.1.tgz",
-      "integrity": "sha512-nxNskZwpgptCUWyci+jiM5IrKY6xSaTpv3xzgkL6NCU+5PyCxyp0Z6jE8NDvew9jolzOC9pBhGJAW26A/jbFqg==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.4.2.tgz",
+      "integrity": "sha512-e5rP/RLujp06wmO75njxnfi3ndOBbgHIXceAsuN870BVh7D7iGx+8bwslIWy+FwRBYsCMCnWk+d25Zp4ai3p4w==",
       "license": "MIT",
       "dependencies": {
         "ts-dedent": "^2.0.0"
@@ -6012,7 +6012,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.4.1"
+        "storybook": "^10.4.2"
       }
     },
     "node_modules/@storybook/builder-vite": {
@@ -19193,9 +19193,9 @@
       }
     },
     "node_modules/storybook": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.1.tgz",
-      "integrity": "sha512-V1Zd2e+gBFufqAQVZ1JR8KLqALsEZ3JYSBnWwQbKa6zCfWWanR6AFMyuOkLt2gZOgGp3h2Riuz88pGNVTQSG0A==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.2.tgz",
+      "integrity": "sha512-5Ax5vbHxFgMBGGhQDm75Rrumm/HZC4ICFhMcJaM0UlqnC/4FKj/IaZtImZFupknyiiyUEcWHPQFA2kX3/VSv1A==",
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@storybook/react-vite": "^10.1.4",
         "@vituum/vite-plugin-twig": "^1.1.0",
         "autoprefixer": "^10.4.21",
+        "axe-core": "^4.11.4",
         "babel-preset-minify": "^0.5.2",
         "concurrently": "^9.2.1",
         "eslint": "^9.39.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13399,16 +13399,16 @@
       "license": "MIT"
     },
     "node_modules/lint-staged": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.5.tgz",
-      "integrity": "sha512-d12yC+/e8RhBjZtaxZn71FyrgU/P5e+uAPifhCLwdosQZP/zamSdKRWDC30ocVIbzDKiFG1McHc/LUgB92GIPw==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.7.tgz",
+      "integrity": "sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "listr2": "^10.2.1",
         "picomatch": "^4.0.4",
         "string-argv": "^0.3.2",
-        "tinyexec": "^1.1.2"
+        "tinyexec": "^1.2.4"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -13420,7 +13420,7 @@
         "url": "https://opencollective.com/lint-staged"
       },
       "optionalDependencies": {
-        "yaml": "^2.8.4"
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/lint-staged/node_modules/picomatch": {
@@ -20350,9 +20350,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4775,12 +4775,12 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
@@ -10290,13 +10290,13 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
-      "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
+      "integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
       "license": "MIT",
       "dependencies": {
         "prettier-linter-helpers": "^1.0.1",
-        "synckit": "^0.11.12"
+        "synckit": "^0.11.13"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -20115,12 +20115,12 @@
       "license": "MIT"
     },
     "node_modules/synckit": {
-      "version": "0.11.12",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.2.9"
+        "@pkgr/core": "^0.3.6"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13178,9 +13178,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "@storybook/react-vite": "^10.1.4",
     "@vituum/vite-plugin-twig": "^1.1.0",
     "autoprefixer": "^10.4.21",
+    "axe-core": "^4.11.4",
     "babel-preset-minify": "^0.5.2",
     "concurrently": "^9.2.1",
     "eslint": "^9.39.4",

--- a/scripts/a11y.js
+++ b/scripts/a11y.js
@@ -62,7 +62,6 @@ const applyProjectA11yConfig = (config = {}) => {
  * @returns {void}
  */
 const printHelp = () => {
-  // eslint-disable-next-line no-console
   console.log(
     [
       'Usage: node scripts/a11y.js [options]',
@@ -128,7 +127,6 @@ const logIssue = ({ type: severity, message, context, selector }) => {
     `selector: ${selector}`,
     '',
   ];
-  // eslint-disable-next-line no-console
   console.log(lines.join('\n'));
 };
 
@@ -142,11 +140,9 @@ const logReport = ({ issues, pageUrl }) => {
   const hasIssues = validIssues.length > 0;
 
   if (hasIssues) {
-    // eslint-disable-next-line no-console
     console.log(`Issues found in component: ${pageUrl}`);
     validIssues.forEach(logIssue);
   } else {
-    // eslint-disable-next-line no-console
     console.log(`No issues found in component: ${pageUrl}`);
   }
 

--- a/scripts/a11y.test.js
+++ b/scripts/a11y.test.js
@@ -16,9 +16,7 @@ import {
   lintReportAndExit,
 } from './a11y.js';
 
-const mockExit = jest
-  .spyOn(global.process, 'exit')
-  .mockImplementation(() => {});
+jest.spyOn(global.process, 'exit').mockImplementation(() => {});
 jest.mock('pa11y', () => jest.fn());
 jest.spyOn(global.console, 'log').mockImplementation(() => {});
 const { ignore, storybookBuildDir, pa11y: pa11yConfig } = a11yConfig;

--- a/scripts/release-fixtures.js
+++ b/scripts/release-fixtures.js
@@ -106,10 +106,10 @@ const releaseFixtures = [
     name: 'mixed-storybook',
     type: 'storybook',
     assert: ['.out/iframe.html'],
-    match: ['.out/assets/card.stories-*.js'],
+    match: ['.out/storybook-assets/card.stories-*.js'],
     assertContent: [
       {
-        pattern: '.out/assets/card.stories-*.js',
+        pattern: '.out/storybook-assets/card.stories-*.js',
         strings: ['Twig fixture', 'React fixture'],
       },
     ],
@@ -119,7 +119,7 @@ const releaseFixtures = [
     type: 'storybook',
     setup: setupLargeTwigStorybookFixture,
     assert: ['.out/iframe.html'],
-    match: ['.out/assets/gallery.stories-*.js'],
+    match: ['.out/storybook-assets/gallery.stories-*.js'],
     measure: true,
     metricComponentCount: largeTwigComponentCount,
   },

--- a/src/storybook/preview-parameters.js
+++ b/src/storybook/preview-parameters.js
@@ -33,7 +33,6 @@ export function mergePreviewParameters(defaults = {}, overrides = {}) {
     if (value === undefined) continue;
 
     // Storybook parameter keys are intentionally dynamic.
-    // eslint-disable-next-line security/detect-object-injection
     const current = merged[key];
     const nextValue =
       isPlainObject(current) && isPlainObject(value)
@@ -41,7 +40,6 @@ export function mergePreviewParameters(defaults = {}, overrides = {}) {
         : value;
 
     // Storybook parameter keys are intentionally dynamic.
-    // eslint-disable-next-line security/detect-object-injection
     merged[key] = nextValue;
   }
 

--- a/src/storybook/twig/resolver.js
+++ b/src/storybook/twig/resolver.js
@@ -30,7 +30,6 @@ const ENV = (typeof __EMULSIFY_ENV__ !== 'undefined' && __EMULSIFY_ENV__) || {};
 function resolveFromMap(map, candidates) {
   for (const key of candidates) {
     // Vite glob map keys are generated from static Storybook patterns.
-    // eslint-disable-next-line security/detect-object-injection
     const value = map[key];
     if (value) {
       return value.default ?? value;
@@ -114,7 +113,6 @@ function findGlobEntry(map, candidates) {
   for (const key of candidates) {
     if (Object.hasOwnProperty.call(map, key)) {
       // Vite glob map keys are generated from static Storybook patterns.
-      // eslint-disable-next-line security/detect-object-injection
       return { key, value: map[key] };
     }
   }
@@ -240,7 +238,6 @@ export function createTwigResolver({
     candidateKeysForReference: (name) => candidateKeysForReference(name, env),
     resolveTemplate(name) {
       // Direct lookups support callers that already resolved a Vite glob key.
-      // eslint-disable-next-line security/detect-object-injection
       const direct = modules[name];
       if (direct) {
         return direct.default ?? direct;


### PR DESCRIPTION
**This PR does the following:**

- Promotes the latest `develop` changes to `main`.
- Fixes Storybook production-build asset paths by:
  - Serving project `assets` and compiled `dist/assets` files from `/assets`.
  - Serving other compiled `dist` files from `/dist`.
  - Writing Storybook-generated chunks to `.out/storybook-assets`.
- Resolves Storybook static directories from the consuming project root, whether `@emulsify/core` is linked locally or installed from `node_modules`.
- Prevents Vite from clearing the Storybook output directory while static files are copied.
- Updates the ESLint configuration to remove false-positive warnings for intentional filesystem, regular expression, and dynamic object-key usage.
- Removes obsolete inline ESLint suppressions and performs related lint-only cleanup.
- Adds `axe-core` as an explicit dependency of the shared Storybook preview configuration.
- Adds regression tests and updates release fixtures for the new Storybook asset layout.

### Related Issue(s)

- N/A

### Related PR(s)

- #256
- #257

### Notes:

- Existing project asset references under `/assets` remain unchanged.
- Generated Storybook chunks move from `.out/assets` to `.out/storybook-assets`.
- Files outside `dist/assets` are now available under `/dist` instead of at the Storybook output root.
- The ESLint security plugin remains enabled. This change disables specific heuristics that produce false positives for intentional tooling patterns.
- The lint cleanup does not change application features or runtime behavior.

### Functional Testing:

- [ ] Run `npm run lint`.
- [ ] Run `npm run test`.
- [ ] Run `npm run fixtures:release`.
- [ ] Run `npm run storybook-build` in a consuming project.
- [ ] Confirm generated Storybook chunks are written to `.out/storybook-assets`.
- [ ] Confirm files from `assets` and `dist/assets` resolve under `/assets`.
- [ ] Confirm other compiled files from `dist` resolve under `/dist`.
- [ ] Confirm Storybook accessibility parameters continue to load correctly.

### Security

No new user-input handling or external execution paths are introduced. The ESLint changes disable noisy static-analysis heuristics for intentional build-tooling patterns; the remaining recommended security rules stay enabled.

### Accessibility

No rendered markup, styles, or interactive behavior are changed. Adding `axe-core` as a direct dependency formalizes the existing dependency used by the shared Storybook accessibility configuration.