### PR TITLE
feat(config): support custom Twig asset roots

### DIFF
--- a/config/vite/environment.js
+++ b/config/vite/environment.js
@@ -9,6 +9,7 @@
  *  - `SDC`: boolean from project.emulsify.json `project.singleDirectoryComponents`.
  *  - `structureOverrides`: true when safe `variant.structureImplementations` exist.
  *  - `structureRoots`: array of directories from `variant.structureImplementations`.
+ *  - `assetRoots`: array of directories from safe `assets.roots` config.
  *  - `platformAdapter`: active adapter for platform-specific behavior.
  */
 
@@ -26,6 +27,7 @@ import { resolveProjectConfig } from './project-config.js';
  *   structureOverrides: boolean,
  *   structureRoots: string[],
  *   structureImplementations: Array<{name: string, directory: string}>,
+ *   assetRoots: string[],
  *   componentRoots: string[],
  *   globalRoots: string[],
  *   namespaceRoots: Record<string, string>,

--- a/config/vite/plugins/virtual-twig-asset-sources.test.js
+++ b/config/vite/plugins/virtual-twig-asset-sources.test.js
@@ -6,6 +6,11 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
+  resetProjectConfigCache,
+  resolveProjectConfig,
+} from '../project-config.js';
+import {
+  assetSourceRoots,
   assetSourceGlobPatterns,
   generateVirtualTwigAssetSourcesModule,
   generatedAssetSourceRoots,
@@ -24,6 +29,7 @@ describe('virtual Twig asset source module plugin', () => {
     if (projectDir) {
       rmSync(projectDir, { recursive: true, force: true });
     }
+    resetProjectConfigCache();
   });
 
   it('resolves and loads the virtual module', () => {
@@ -115,6 +121,32 @@ describe('virtual Twig asset source module plugin', () => {
       },
     };
 
+    expect(assetSourceGlobPatterns(env)).toEqual([
+      '/design/assets/**/*.{svg,html,twig,css,js,json,txt,md}',
+      '/assets/**/*.{svg,html,twig,css,js,json,txt,md}',
+    ]);
+  });
+
+  it('uses asset roots normalized from project.emulsify.json', () => {
+    projectDir = makeTempProject();
+    const assetRoot = join(projectDir, 'design/assets');
+    mkdirSync(assetRoot, { recursive: true });
+    mkdirSync(join(projectDir, 'assets'), { recursive: true });
+    writeFileSync(
+      join(projectDir, 'project.emulsify.json'),
+      JSON.stringify({
+        project: {
+          platform: 'none',
+        },
+        assets: {
+          roots: ['./design/assets'],
+        },
+      }),
+    );
+    const env = resolveProjectConfig(projectDir, {});
+
+    expect(env.projectStructure.assetRoots).toEqual([assetRoot]);
+    expect(assetSourceRoots(env)).toEqual(['/design/assets', '/assets']);
     expect(assetSourceGlobPatterns(env)).toEqual([
       '/design/assets/**/*.{svg,html,twig,css,js,json,txt,md}',
       '/assets/**/*.{svg,html,twig,css,js,json,txt,md}',

--- a/config/vite/project-config.js
+++ b/config/vite/project-config.js
@@ -95,6 +95,31 @@ function normalizeStructureImplementations(projectDir, implementations = []) {
 }
 
 /**
+ * Normalize project asset roots.
+ *
+ * @param {string} projectDir - Absolute project root.
+ * @param {Array} roots - Raw asset root entries.
+ * @returns {string[]} Safe absolute asset root paths.
+ */
+function normalizeAssetRoots(projectDir, roots = []) {
+  if (!Array.isArray(roots)) return [];
+
+  const seen = new Set();
+
+  return roots
+    .map((root) =>
+      typeof root === 'string' ? coerceToProjectPath(projectDir, root) : null,
+    )
+    .filter(Boolean)
+    .map((root) => normalize(root))
+    .filter((root) => {
+      if (seen.has(root)) return false;
+      seen.add(root);
+      return true;
+    });
+}
+
+/**
  * Normalize project config for current tooling consumers.
  *
  * @param {string} [projectDir=process.cwd()] - Absolute project root.
@@ -140,6 +165,7 @@ export function resolveProjectConfig(
     root,
     rawStructureImplementations,
   );
+  const assetRoots = normalizeAssetRoots(root, rawConfig?.assets?.roots);
   const structureRoots = structureImplementations.map(
     (implementation) => implementation.directory,
   );
@@ -149,6 +175,7 @@ export function resolveProjectConfig(
     srcExists,
     SDC: singleDirectoryComponents,
     structureImplementations,
+    assetRoots,
     platformAdapter,
   });
 
@@ -166,6 +193,7 @@ export function resolveProjectConfig(
     structureOverrides: projectStructure.structureOverrides,
     structureImplementations,
     structureRoots,
+    assetRoots,
     componentRoots: projectStructure.componentRoots,
     globalRoots: projectStructure.globalRoots,
     namespaceRoots: projectStructure.namespaceRoots,

--- a/config/vite/project-config.test.js
+++ b/config/vite/project-config.test.js
@@ -285,4 +285,56 @@ describe('resolveProjectConfig', () => {
       components: join(projectDir, 'src/components'),
     });
   });
+
+  it('normalizes documented assets.roots into project structure asset roots', () => {
+    projectDir = makeTempProject();
+    mkdirSync(join(projectDir, 'design-system/assets'), {
+      recursive: true,
+    });
+    mkdirSync(join(projectDir, 'prototype-assets'), { recursive: true });
+    writeProjectConfig(projectDir, {
+      project: {
+        platform: 'none',
+      },
+      assets: {
+        roots: ['./design-system/assets/', './prototype-assets'],
+      },
+    });
+
+    const env = resolveProjectConfig(projectDir, {});
+    const expectedRoots = [
+      join(projectDir, 'design-system/assets'),
+      join(projectDir, 'prototype-assets'),
+    ];
+
+    expect(env.assetRoots).toEqual(expectedRoots);
+    expect(env.projectStructure.assetRoots).toEqual(expectedRoots);
+  });
+
+  it('ignores unsafe asset root paths', () => {
+    projectDir = makeTempProject();
+    mkdirSync(join(projectDir, 'src/assets'), { recursive: true });
+    writeProjectConfig(projectDir, {
+      project: {
+        platform: 'none',
+      },
+      assets: {
+        roots: [
+          '../shared-assets',
+          '/tmp/outside-assets',
+          './src/assets',
+          './src/assets',
+          '',
+          42,
+        ],
+      },
+    });
+
+    const env = resolveProjectConfig(projectDir, {});
+
+    expect(env.assetRoots).toEqual([join(projectDir, 'src/assets')]);
+    expect(env.projectStructure.assetRoots).toEqual([
+      join(projectDir, 'src/assets'),
+    ]);
+  });
 });

--- a/config/vite/project-structure.js
+++ b/config/vite/project-structure.js
@@ -7,7 +7,7 @@
  * process.
  */
 
-import { basename, relative, resolve, sep } from 'path';
+import { basename, normalize, relative, resolve, sep } from 'path';
 import { safeExists } from './utils/fs-safe.js';
 import { replaceLastSlash, toPosixPath } from './utils/paths.js';
 import { unique } from './utils/unique.js';
@@ -182,6 +182,33 @@ function fallbackNamespaceRoots({
 }
 
 /**
+ * Normalize project-scoped asset roots.
+ *
+ * @param {string} projectDir - Absolute project root.
+ * @param {string[]} assetRoots - Raw asset root paths.
+ * @returns {string[]} Safe absolute asset root paths.
+ */
+function normalizeAssetRoots(projectDir, assetRoots = []) {
+  if (!Array.isArray(assetRoots)) return [];
+
+  const projectRoot = resolve(projectDir);
+
+  return unique(
+    assetRoots
+      .map((root) =>
+        typeof root === 'string' && root.trim()
+          ? normalize(resolve(projectRoot, root))
+          : '',
+      )
+      .filter(
+        (root) =>
+          root &&
+          (root === projectRoot || root.startsWith(`${projectRoot}${sep}`)),
+      ),
+  );
+}
+
+/**
  * Resolve the serializable project structure model.
  *
  * @param {{
@@ -190,6 +217,7 @@ function fallbackNamespaceRoots({
  *   srcExists?: boolean,
  *   SDC?: boolean,
  *   structureImplementations?: {name: string, directory: string}[],
+ *   assetRoots?: string[],
  *   platformAdapter?: object
  * }} [env] - Normalized project environment.
  * @returns {object} Project structure model.
@@ -244,6 +272,7 @@ export function resolveProjectStructure(env) {
       });
   const componentRoots = componentRootRecords.map((root) => root.directory);
   const globalRoots = globalRootRecords.map((root) => root.directory);
+  const assetRoots = normalizeAssetRoots(projectDir, resolvedEnv.assetRoots);
   const namespaceRootValues = Object.values(namespaceRoots);
   const sourceRoots = unique(
     [...componentRoots, ...globalRoots].filter(Boolean),
@@ -278,6 +307,7 @@ export function resolveProjectStructure(env) {
     globalRootRecords,
     componentRoots,
     globalRoots,
+    assetRoots,
     sourceRoots,
     sourceRootRecords,
     storyRoots,

--- a/config/vite/project-structure.test.js
+++ b/config/vite/project-structure.test.js
@@ -70,4 +70,30 @@ describe('resolveProjectStructure', () => {
 
     expect(second).toBe(first);
   });
+
+  it('includes normalized asset roots in the project structure model', () => {
+    const env = makeEnv();
+    env.assetRoots = ['./src/assets', join(env.projectDir, 'design/assets')];
+
+    const structure = resolveProjectStructure(env);
+
+    expect(structure.assetRoots).toEqual([
+      join(env.projectDir, 'src/assets'),
+      join(env.projectDir, 'design/assets'),
+    ]);
+  });
+
+  it('ignores unsafe asset roots in the project structure model', () => {
+    const env = makeEnv();
+    env.assetRoots = [
+      '../shared-assets',
+      '/tmp/outside-assets',
+      './src/assets',
+      './src/assets',
+    ];
+
+    const structure = resolveProjectStructure(env);
+
+    expect(structure.assetRoots).toEqual([join(env.projectDir, 'src/assets')]);
+  });
 });

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,8 @@ These docs expand on the short project README and are organized by the task a pr
 | [Version Evolution](version-evolution.md)            | Understanding how Emulsify Core has evolved across major releases.                                                    |
 | [Component Authoring](component-authoring.md)        | Choosing Twig, React, or mixed Storybook authoring and comparing component examples.                                  |
 | [Storybook](storybook.md)                            | Rendering Twig stories, using `renderTwig()`, understanding Twig runtime helpers, and mixing Twig with React stories. |
-| [Project Structure And Output](project-structure.md) | Configuring `src/components`, root `./components`, `variant.structureImplementations`, and expected output paths.     |
-| [Asset References](asset-references.md)              | Referencing fonts, SVGs, images, and other files from project root `assets/` in Sass, CSS, and Twig.                  |
+| [Project Structure And Output](project-structure.md) | Configuring `src/components`, root `./components`, `variant.structureImplementations`, asset roots, and output paths. |
+| [Asset References](asset-references.md)              | Referencing fonts, SVGs, images, and other files from project root or configured asset roots in Sass, CSS, and Twig.  |
 | [Platform Adapters](platform-adapters.md)            | Understanding `none`, `drupal`, platform resolution order, and Drupal SDC behavior.                                   |
 | [Extension Points](extension-points.md)              | Adding Vite plugins, Tailwind CSS, Storybook preview overrides, and other framework tooling.                          |
 | [Performance](performance.md)                        | Understanding sourcemaps, eager Twig imports, Tailwind scanning, copied files, and fixture validation.                |

--- a/docs/asset-references.md
+++ b/docs/asset-references.md
@@ -15,6 +15,21 @@ assets/
     example.png
 ```
 
+Projects that keep Storybook text assets in additional directories can declare
+custom asset roots in `project.emulsify.json`:
+
+```json
+{
+  "assets": {
+    "roots": ["./design-system/assets", "./prototype-assets"]
+  }
+}
+```
+
+Configured roots are resolved relative to the project root. Paths that resolve
+outside the project are ignored. Existing root `assets/` and `src/assets/`
+directories are always included for `@assets` source lookups.
+
 ## Sass And CSS
 
 Sass and CSS should reference project assets with `/assets/...` URLs.
@@ -59,9 +74,9 @@ through Emulsify's Storybook Twig helpers.
 ```
 
 For text assets such as SVG, HTML, Twig, CSS, JavaScript, JSON, TXT, and
-Markdown, `source('@assets/...')` reads from configured asset roots and always
-includes existing root `assets` and `src/assets` directories. Root `./assets`
-is checked before `./src/assets`.
+Markdown, `source('@assets/...')` reads from `assets.roots` and always includes
+existing root `assets` and `src/assets` directories. Root `./assets` is checked
+before `./src/assets`.
 
 The generated SVG sprite is a special case:
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -1,6 +1,6 @@
 # Project Structure And Output
 
-Emulsify Core reads `project.emulsify.json` once and normalizes project structure for Vite, Storybook, Twig namespaces, and copy behavior.
+Emulsify Core reads `project.emulsify.json` once and normalizes project structure for Vite, Storybook, Twig namespaces, asset roots, and copy behavior.
 
 ## Which Structure Should I Use?
 
@@ -66,6 +66,29 @@ Projects using this structure do not need to create `src/` just to use the curre
 ```
 
 Each implementation name becomes a structure root and Twig namespace, so templates can reference names such as `@components`, `@foundation`, `@layout`, and `@tokens`. Configured paths that resolve outside the project root are ignored.
+
+### `assets.roots`
+
+`assets.roots` declares additional project directories that Storybook can use
+for `source('@assets/...')` text asset lookups.
+
+```json
+{
+  "project": {
+    "platform": "none",
+    "name": "example",
+    "machineName": "example"
+  },
+  "assets": {
+    "roots": ["./design-system/assets", "./prototype-assets"]
+  }
+}
+```
+
+Each root is normalized into `projectStructure.assetRoots` as an absolute path.
+Configured paths that resolve outside the project root are ignored. Existing
+root `assets/` and `src/assets/` directories are still checked automatically
+for `@assets` references.
 
 ## Story Roots
 

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -230,7 +230,17 @@ It also supports the Storybook asset alias `@assets` for static assets served fr
 {{ source('@assets/images/example.png') }}
 ```
 
-Text assets such as SVG, HTML, Twig, CSS, JavaScript, JSON, TXT, and Markdown are resolved from a build-time virtual module when they live under configured asset roots. Emulsify uses `projectStructure.assetRoots` when available and always includes existing root `assets` and `src/assets` directories. Root `./assets` is checked before `./src/assets` for `@assets` references.
+Text assets such as SVG, HTML, Twig, CSS, JavaScript, JSON, TXT, and Markdown are resolved from a build-time virtual module when they live under configured asset roots. Projects can add custom roots with `assets.roots` in `project.emulsify.json`; Emulsify normalizes those paths into `projectStructure.assetRoots` and always includes existing root `assets` and `src/assets` directories. Root `./assets` is checked before `./src/assets` for `@assets` references.
+
+```json
+{
+  "assets": {
+    "roots": ["./design-system/assets", "./prototype-assets"]
+  }
+}
+```
+
+Configured asset roots must resolve inside the project root. Unsafe paths are ignored.
 
 The generated sprite is a special asset alias: `source('@assets/icons.svg')` resolves `dist/assets/icons.svg` before checking root `assets/icons.svg`. Other `@assets/...` SVG references resolve through the project asset roots, so `source('@assets/icons/arrow.svg')` reads `assets/icons/arrow.svg` when that file exists.
 

--- a/scripts/audit.test.js
+++ b/scripts/audit.test.js
@@ -498,6 +498,37 @@ No audit findings found."
     ).toBe(true);
   });
 
+  it('resolves source() asset references from assets.roots config', () => {
+    const quote = String.fromCharCode(39);
+
+    writeFile(
+      projectDir,
+      'project.emulsify.json',
+      JSON.stringify({
+        project: {
+          platform: 'none',
+        },
+        assets: {
+          roots: ['./custom-assets'],
+        },
+      }),
+    );
+    writeFile(
+      projectDir,
+      'src/components/icon/icon.twig',
+      `{{ source(${quote}@assets/icons/foo.svg${quote}) }}`,
+    );
+    writeFile(projectDir, 'custom-assets/icons/foo.svg', '<svg></svg>');
+
+    const result = auditProject({ projectDir });
+
+    expect(
+      result.findings.filter(
+        (finding) => finding.id === 'unresolved-twig-reference',
+      ),
+    ).toHaveLength(0);
+  });
+
   it('only treats first include/source argument strings as template references', () => {
     const quote = String.fromCharCode(39);
 


### PR DESCRIPTION
**Summary**

Adds support for configuring additional Storybook text asset roots through `assets.roots` in `project.emulsify.json`.

- Normalizes configured asset roots into safe, deduplicated absolute project paths.
- Exposes the normalized paths through `assetRoots` and `projectStructure.assetRoots`.
- Includes configured roots when resolving Twig `source('@assets/...')` references.
- Preserves the existing `assets/` and `src/assets/` fallback roots.
- Ignores empty, invalid, duplicate, and out-of-project paths.
- Updates the audit command to resolve `source()` references from configured asset roots.
- Adds regression coverage for configuration normalization, project structure resolution, virtual asset globs, and audit behavior.
- Documents the new configuration in the asset reference, project structure, and Storybook guides.

**Related issue(s)**

- N/A

**Checklist**

- [x] Tests run and results noted — CI completed successfully.
- [x] Documentation impact considered — relevant documentation has been updated.
- [x] Migration or backward compatibility impact considered — this is additive and existing projects require no changes.
- [x] Accessibility impact considered — no accessibility behavior is affected.
- [x] Release fixture impact considered — no release fixture changes are required.

**Notes**

Example configuration:

```json
{
  "assets": {
    "roots": ["./design-system/assets", "./prototype-assets"]
  }
}