### PR TITLE
fix(twig): resolve deeply grouped project components

### DIFF
--- a/.github/fixtures/release/mixed-storybook/src/components/atoms/text/headings/headings.twig
+++ b/.github/fixtures/release/mixed-storybook/src/components/atoms/text/headings/headings.twig
@@ -1,0 +1,1 @@
+<h3 data-nested-project-alias>{{ text }}</h3>

--- a/.github/fixtures/release/mixed-storybook/src/components/card/card.twig
+++ b/.github/fixtures/release/mixed-storybook/src/components/card/card.twig
@@ -1,5 +1,6 @@
 <article {{ add_attributes({ class: bem('card', ['storybook']) }) }}>
   <h2>{{ heading }}</h2>
+  {% include 'mixed_storybook:headings' with { text: heading } %}
   <p>{{ body }}</p>
   {% if renderedBy %}
     <span data-rendered-by="{{ renderedBy }}">{{ renderedBy }}</span>

--- a/config/vite/plugins/__tests__/twig-module.test.js
+++ b/config/vite/plugins/__tests__/twig-module.test.js
@@ -542,6 +542,360 @@ describe('Twig module plugin', () => {
     expect(output).toContain('<button>Read more</button>');
   });
 
+  it.each([
+    {
+      componentName: 'heading',
+      description: 'directly under the component root',
+      pathParts: ['heading'],
+    },
+    {
+      componentName: 'heading',
+      description: 'under one grouping directory',
+      pathParts: ['typography', 'heading'],
+    },
+    {
+      componentName: 'headings',
+      description: 'under multiple grouping directories',
+      pathParts: ['atoms', 'text', 'headings'],
+    },
+  ])(
+    'resolves project-scoped components $description',
+    ({ componentName, pathParts }) => {
+      projectDir = makeTempProject();
+      const cardFile = join(projectDir, 'src/components/card/card.twig');
+      const headingDir = join(projectDir, 'src/components', ...pathParts);
+      fs.mkdirSync(join(projectDir, 'src/components/card'), {
+        recursive: true,
+      });
+      fs.mkdirSync(headingDir, { recursive: true });
+      fs.writeFileSync(
+        join(headingDir, `${componentName}.twig`),
+        '<h2>{{ title }}</h2>',
+      );
+      fs.writeFileSync(cardFile, `{% include "steinhardt:${componentName}" %}`);
+
+      const twigPlugin = makeTwigModulePlugin(makeEnv(projectDir));
+      const transformed = transformTwigModule(twigPlugin, cardFile);
+      const output = renderGeneratedTwigModule(transformed.code, {
+        title: 'Nested heading',
+      });
+
+      expect(transformed.code).toContain(
+        `__emulsifyIncludeTemplates.set("steinhardt:${componentName}"`,
+      );
+      expect(output).toContain('<h2>Nested heading</h2>');
+      expect(output).not.toContain('Unable to find template file');
+      expect(output).not.toContain('fs.statSync is not a function');
+    },
+  );
+
+  it.each([
+    {
+      dependencyName: 'heading',
+      dependencySource: '<h2>Included</h2>',
+      expected: '<h2>Included</h2>',
+      source: '{% include "steinhardt:heading" %}',
+      tag: 'include',
+    },
+    {
+      dependencyName: 'macros',
+      dependencySource:
+        '{% macro badge(text) %}<span>{{ text }}</span>{% endmacro %}',
+      expected: '<span>Imported</span>',
+      source:
+        '{% import "steinhardt:macros" as components %}{{ components.badge("Imported") }}',
+      tag: 'import',
+    },
+    {
+      dependencyName: 'frame',
+      dependencySource: '<section>{% block content %}{% endblock %}</section>',
+      expected: '<section>Embedded</section>',
+      source:
+        '{% embed "steinhardt:frame" %}{% block content %}Embedded{% endblock %}{% endembed %}',
+      tag: 'embed',
+    },
+    {
+      dependencyName: 'shell',
+      dependencySource: '<main>{% block content %}{% endblock %}</main>',
+      expected: '<main>Extended</main>',
+      source:
+        '{% extends "steinhardt:shell" %}{% block content %}Extended{% endblock %}',
+      tag: 'extends',
+    },
+    {
+      dependencyName: 'macros',
+      dependencySource:
+        '{% macro badge(text) %}<span>{{ text }}</span>{% endmacro %}',
+      expected: '<span>From</span>',
+      source: '{% from "steinhardt:macros" import badge %}{{ badge("From") }}',
+      tag: 'from',
+    },
+  ])(
+    'resolves nested project-scoped $tag references',
+    ({ dependencyName, dependencySource, expected, source }) => {
+      projectDir = makeTempProject();
+      const cardDir = join(projectDir, 'src/components/card');
+      const dependencyDir = join(
+        projectDir,
+        'src/components/atoms/text',
+        dependencyName,
+      );
+      const cardFile = join(cardDir, 'card.twig');
+      fs.mkdirSync(cardDir, { recursive: true });
+      fs.mkdirSync(dependencyDir, { recursive: true });
+      fs.writeFileSync(
+        join(dependencyDir, `${dependencyName}.twig`),
+        dependencySource,
+      );
+      fs.writeFileSync(cardFile, source);
+
+      const twigPlugin = makeTwigModulePlugin(makeEnv(projectDir));
+      const transformed = transformTwigModule(twigPlugin, cardFile);
+      const output = renderGeneratedTwigModule(transformed.code);
+
+      expect(output).toContain(expected);
+      expect(output).not.toContain('Unable to find template file');
+      expect(output).not.toContain('fs.statSync is not a function');
+    },
+  );
+
+  it('preserves exact component namespace precedence for nested templates', () => {
+    projectDir = makeTempProject();
+    const cardDir = join(projectDir, 'src/components/card');
+    const exactDir = join(projectDir, 'src/components/atoms/text/headings');
+    const duplicateDir = join(projectDir, 'src/components/molecules/headings');
+    const cardFile = join(cardDir, 'card.twig');
+    fs.mkdirSync(cardDir, { recursive: true });
+    fs.mkdirSync(exactDir, { recursive: true });
+    fs.mkdirSync(duplicateDir, { recursive: true });
+    fs.writeFileSync(join(exactDir, 'heading.twig'), '<h2>Exact heading</h2>');
+    fs.writeFileSync(
+      join(duplicateDir, 'heading.twig'),
+      '<h2>Duplicate heading</h2>',
+    );
+    fs.writeFileSync(
+      cardFile,
+      '{% include "@components/atoms/text/headings/heading.twig" %}',
+    );
+
+    const twigPlugin = makeTwigModulePlugin(makeEnv(projectDir));
+    const transformed = transformTwigModule(twigPlugin, cardFile);
+    const output = renderGeneratedTwigModule(transformed.code);
+
+    expect(output).toContain('<h2>Exact heading</h2>');
+    expect(output).not.toContain('Duplicate heading');
+  });
+
+  it('resolves duplicate project-scoped component names deterministically', () => {
+    projectDir = makeTempProject();
+    const cardDir = join(projectDir, 'src/components/card');
+    const alphaDir = join(projectDir, 'src/components/alpha/heading');
+    const betaDir = join(projectDir, 'src/components/beta/heading');
+    const deeperDir = join(projectDir, 'src/components/aardvark/text/heading');
+    const cardFile = join(cardDir, 'card.twig');
+    fs.mkdirSync(cardDir, { recursive: true });
+    fs.mkdirSync(betaDir, { recursive: true });
+    fs.mkdirSync(deeperDir, { recursive: true });
+    fs.mkdirSync(alphaDir, { recursive: true });
+    fs.writeFileSync(join(betaDir, 'heading.twig'), '<h2>Beta</h2>');
+    fs.writeFileSync(join(deeperDir, 'heading.twig'), '<h2>Deeper</h2>');
+    fs.writeFileSync(join(alphaDir, 'heading.twig'), '<h2>Alpha</h2>');
+    fs.writeFileSync(cardFile, '{% include "steinhardt:heading" %}');
+
+    const twigPlugin = makeTwigModulePlugin(makeEnv(projectDir));
+    const transformed = transformTwigModule(twigPlugin, cardFile);
+    const output = renderGeneratedTwigModule(transformed.code);
+
+    expect(output).toContain('<h2>Alpha</h2>');
+    expect(output).not.toContain('<h2>Beta</h2>');
+    expect(output).not.toContain('<h2>Deeper</h2>');
+  });
+
+  it('resolves nested transitive project-scoped dependencies', () => {
+    projectDir = makeTempProject();
+    const pageDir = join(projectDir, 'src/components/page');
+    const cardDir = join(projectDir, 'src/components/molecules/cards/card');
+    const headingDir = join(projectDir, 'src/components/atoms/text/heading');
+    const pageFile = join(pageDir, 'page.twig');
+    fs.mkdirSync(pageDir, { recursive: true });
+    fs.mkdirSync(cardDir, { recursive: true });
+    fs.mkdirSync(headingDir, { recursive: true });
+    fs.writeFileSync(join(headingDir, 'heading.twig'), '<h2>{{ title }}</h2>');
+    fs.writeFileSync(
+      join(cardDir, 'card.twig'),
+      '<article>{% include "steinhardt:heading" %}</article>',
+    );
+    fs.writeFileSync(pageFile, '{% include "steinhardt:card" %}');
+
+    const twigPlugin = makeTwigModulePlugin(makeEnv(projectDir));
+    const transformed = transformTwigModule(twigPlugin, pageFile);
+    const output = renderGeneratedTwigModule(transformed.code, {
+      title: 'Transitive heading',
+    });
+
+    expect(output).toContain('<article><h2>Transitive heading</h2></article>');
+  });
+
+  it('skips unreadable grouped component directories', () => {
+    projectDir = makeTempProject();
+    const cardDir = join(projectDir, 'src/components/card');
+    const privateDir = join(projectDir, 'src/components/atoms/private');
+    const headingDir = join(projectDir, 'src/components/atoms/public/heading');
+    const cardFile = join(cardDir, 'card.twig');
+    fs.mkdirSync(cardDir, { recursive: true });
+    fs.mkdirSync(privateDir, { recursive: true });
+    fs.mkdirSync(headingDir, { recursive: true });
+    fs.writeFileSync(join(headingDir, 'heading.twig'), '<h2>Public</h2>');
+    fs.writeFileSync(cardFile, '{% include "steinhardt:heading" %}');
+    const realReaddirSync = fs.readdirSync.bind(fs);
+    jest.spyOn(fs, 'readdirSync').mockImplementation((directory, options) => {
+      if (directory === privateDir) {
+        throw new Error('EACCES');
+      }
+      return realReaddirSync(directory, options);
+    });
+
+    const twigPlugin = makeTwigModulePlugin(makeEnv(projectDir));
+    const transformed = transformTwigModule(twigPlugin, cardFile);
+
+    expect(renderGeneratedTwigModule(transformed.code)).toContain(
+      '<h2>Public</h2>',
+    );
+  });
+
+  it('does not resolve project-scoped traversal outside the component root', () => {
+    projectDir = makeTempProject();
+    const cardDir = join(projectDir, 'src/components/card');
+    const outsideDir = join(projectDir, 'src/outside/heading');
+    const cardFile = join(cardDir, 'card.twig');
+    fs.mkdirSync(cardDir, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(join(outsideDir, 'heading.twig'), '<h2>Outside root</h2>');
+    fs.writeFileSync(
+      cardFile,
+      '{% include "steinhardt:../../outside/heading" %}',
+    );
+
+    const twigPlugin = makeTwigModulePlugin(makeEnv(projectDir));
+    const transformed = transformTwigModule(twigPlugin, cardFile);
+    const output = renderGeneratedTwigModule(transformed.code);
+
+    expect(output).not.toContain('Outside root');
+    expect(output).toContain('Unable to find template');
+    expect(output).not.toContain('fs.statSync is not a function');
+  });
+
+  it('keeps unresolved static templates away from the Twig.js fs loader', () => {
+    projectDir = makeTempProject();
+    const cardDir = join(projectDir, 'src/components/card');
+    const cardFile = join(cardDir, 'card.twig');
+    fs.mkdirSync(cardDir, { recursive: true });
+    fs.writeFileSync(cardFile, '{% include "steinhardt:missing" %}');
+
+    const twigPlugin = makeTwigModulePlugin(makeEnv(projectDir));
+    const transformed = transformTwigModule(twigPlugin, cardFile);
+    const runtimeTwig = Twig.factory();
+    let fsLoaderUsed = false;
+    runtimeTwig.extend((TwigCore) => {
+      TwigCore.Templates.registerLoader('fs', () => {
+        fsLoaderUsed = true;
+        throw new Error('fs loader used');
+      });
+    });
+
+    const output = renderGeneratedTwigModule(transformed.code, {}, runtimeTwig);
+
+    expect(fsLoaderUsed).toBe(false);
+    expect(output).toContain('Unable to find template steinhardt:missing');
+    expect(output).not.toContain('fs.statSync is not a function');
+  });
+
+  it('invalidates nested component traversal when HMR adds a directory', () => {
+    projectDir = makeTempProject();
+    const cardDir = join(projectDir, 'src/components/card');
+    const headingDir = join(projectDir, 'src/components/atoms/text/heading');
+    const cardFile = join(cardDir, 'card.twig');
+    const headingFile = join(headingDir, 'heading.twig');
+    fs.mkdirSync(cardDir, { recursive: true });
+    fs.writeFileSync(cardFile, '{% include "steinhardt:heading" %}');
+
+    const twigPlugin = makeTwigModulePlugin(makeEnv(projectDir));
+    const initial = transformTwigModule(twigPlugin, cardFile);
+    expect(renderGeneratedTwigModule(initial.code)).toContain(
+      'Unable to find template',
+    );
+
+    fs.mkdirSync(headingDir, { recursive: true });
+    fs.writeFileSync(headingFile, '<h2>Added by HMR</h2>');
+    const importerModule = { id: 'card-template' };
+    const server = {
+      moduleGraph: {
+        getModulesByFile: jest.fn((filePath) =>
+          filePath === cardFile ? [importerModule] : [],
+        ),
+        invalidateModule: jest.fn(),
+      },
+    };
+
+    const updatedModules = twigPlugin.handleHotUpdate({
+      file: headingFile,
+      server,
+    });
+    const updated = transformTwigModule(twigPlugin, cardFile);
+
+    expect(server.moduleGraph.invalidateModule).toHaveBeenCalledWith(
+      importerModule,
+    );
+    expect(updatedModules).toContain(importerModule);
+    expect(renderGeneratedTwigModule(updated.code)).toContain(
+      '<h2>Added by HMR</h2>',
+    );
+  });
+
+  it('invalidates nested component traversal when HMR removes a directory', () => {
+    projectDir = makeTempProject();
+    const cardDir = join(projectDir, 'src/components/card');
+    const headingDir = join(projectDir, 'src/components/atoms/text/heading');
+    const cardFile = join(cardDir, 'card.twig');
+    const headingFile = join(headingDir, 'heading.twig');
+    fs.mkdirSync(cardDir, { recursive: true });
+    fs.mkdirSync(headingDir, { recursive: true });
+    fs.writeFileSync(headingFile, '<h2>Removed by HMR</h2>');
+    fs.writeFileSync(cardFile, '{% include "steinhardt:heading" %}');
+
+    const twigPlugin = makeTwigModulePlugin(makeEnv(projectDir));
+    const initial = transformTwigModule(twigPlugin, cardFile);
+    expect(renderGeneratedTwigModule(initial.code)).toContain(
+      '<h2>Removed by HMR</h2>',
+    );
+
+    fs.rmSync(headingDir, { recursive: true, force: true });
+    const importerModule = { id: 'card-template' };
+    const server = {
+      moduleGraph: {
+        getModulesByFile: jest.fn((filePath) =>
+          filePath === cardFile ? [importerModule] : [],
+        ),
+        invalidateModule: jest.fn(),
+      },
+    };
+
+    const updatedModules = twigPlugin.handleHotUpdate({
+      file: headingFile,
+      server,
+    });
+    const updated = transformTwigModule(twigPlugin, cardFile);
+    const output = renderGeneratedTwigModule(updated.code);
+
+    expect(server.moduleGraph.invalidateModule).toHaveBeenCalledWith(
+      importerModule,
+    );
+    expect(updatedModules).toContain(importerModule);
+    expect(output).not.toContain('Removed by HMR');
+    expect(output).toContain('Unable to find template');
+    expect(output).not.toContain('fs.statSync is not a function');
+  });
+
   it('preserves runtime rethrow for precompiled templates', () => {
     projectDir = makeTempProject();
     const cardFile = join(projectDir, 'src/components/card/card.twig');

--- a/config/vite/plugins/twig-module.js
+++ b/config/vite/plugins/twig-module.js
@@ -75,6 +75,13 @@ const compileCache = new Map();
 const resolutionCache = new Map();
 
 /**
+ * Cache recursively discovered component grouping directories by root.
+ *
+ * @type {Map<string, string[]>}
+ */
+const componentGroupRootsCache = new Map();
+
+/**
  * Track Twig files that have been seen during this build/session.
  *
  * Known files can keep include-resolution cache entries across ordinary content
@@ -356,6 +363,43 @@ const isWithinRoot = (root, filePath) => {
 };
 
 /**
+ * Return the first component template candidate contained by its configured root.
+ *
+ * Both lexical and real paths are checked so `..` segments and symlinks cannot
+ * escape the component root.
+ *
+ * @param {string[]} paths - Candidate absolute paths.
+ * @param {string} componentRoot - Absolute component root path.
+ * @returns {string|undefined} Existing component template path.
+ */
+const findExistingComponentTemplateFile = (paths, componentRoot) => {
+  const absoluteRoot = resolve(componentRoot);
+  let realRoot;
+
+  try {
+    realRoot = fs.realpathSync(absoluteRoot);
+  } catch {
+    return undefined;
+  }
+
+  return paths.filter(Boolean).find((filePath) => {
+    const absoluteFilePath = resolve(filePath);
+    if (!isWithinRoot(absoluteRoot, absoluteFilePath)) {
+      return false;
+    }
+
+    try {
+      return (
+        fs.statSync(absoluteFilePath).isFile() &&
+        isWithinRoot(realRoot, fs.realpathSync(absoluteFilePath))
+      );
+    } catch {
+      return false;
+    }
+  });
+};
+
+/**
  * Find the most specific configured Twig root for a template file.
  *
  * @param {string} filePath - Absolute template file path.
@@ -511,7 +555,11 @@ const parseTwigNamespaceReference = (templatePath, namespaces = {}) => {
 };
 
 /**
- * Return immediate directory roots that may group component folders.
+ * Return grouping directories below the configured component root.
+ *
+ * Breadth-first traversal preserves direct and one-level behavior before
+ * searching deeper groups. Siblings use code-point order so duplicate
+ * shorthand names resolve consistently across filesystems.
  *
  * @param {string} componentRoot - Absolute component root path.
  * @returns {string[]} Absolute grouping directory paths.
@@ -519,33 +567,57 @@ const parseTwigNamespaceReference = (templatePath, namespaces = {}) => {
 const componentGroupRoots = (componentRoot) => {
   if (!componentRoot) return [];
 
-  try {
-    // Component group roots come from a configured project directory.
-    return fs
-      .readdirSync(componentRoot, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => resolve(componentRoot, entry.name));
-  } catch {
-    return [];
+  const absoluteRoot = resolve(componentRoot);
+  if (componentGroupRootsCache.has(absoluteRoot)) {
+    return componentGroupRootsCache.get(absoluteRoot);
   }
+
+  const groupRoots = [];
+  const pendingDirectories = [absoluteRoot];
+
+  for (let index = 0; index < pendingDirectories.length; index += 1) {
+    const directory = pendingDirectories[index];
+    let entries;
+
+    try {
+      entries = fs.readdirSync(directory, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    const childDirectories = entries
+      .filter((entry) => entry.isDirectory())
+      .sort(({ name: left }, { name: right }) =>
+        left === right ? 0 : left < right ? -1 : 1,
+      )
+      .map((entry) => resolve(directory, entry.name))
+      .filter((childDirectory) => isWithinRoot(absoluteRoot, childDirectory));
+
+    groupRoots.push(...childDirectories);
+    pendingDirectories.push(...childDirectories);
+  }
+
+  componentGroupRootsCache.set(absoluteRoot, groupRoots);
+  return groupRoots;
 };
 
 /**
- * Resolve a component reference through one grouping directory level.
+ * Resolve a component reference through recursively grouped directories.
  *
  * Project-scoped component IDs can use the component name (`project:button`)
- * even when projects organize components under grouping directories such as
- * `ui`.
+ * even when projects organize components under grouping paths such as
+ * `atoms/text`.
  *
  * @param {string} templatePath - Component-relative template reference.
  * @param {string} componentRoot - Absolute component root path.
  * @returns {string|null} Existing template path when found.
  */
 const resolveGroupedComponentTemplate = (templatePath, componentRoot) =>
-  findExistingTemplateFile(
+  findExistingComponentTemplateFile(
     componentGroupRoots(componentRoot).flatMap((groupRoot) =>
       buildTemplateFileCandidates(groupRoot, templatePath),
     ),
+    componentRoot,
   ) || null;
 
 /**
@@ -562,8 +634,9 @@ const resolveComponentShorthandReference = (templatePath, componentRoot) => {
     templatePath.startsWith('@') && !templatePath.includes('/')
       ? templatePath.slice(1)
       : templatePath;
-  const directComponentPath = findExistingTemplateFile(
+  const directComponentPath = findExistingComponentTemplateFile(
     buildTemplateFileCandidates(componentRoot, shorthandPath),
+    componentRoot,
   );
   if (directComponentPath) {
     return directComponentPath;
@@ -577,8 +650,9 @@ const resolveComponentShorthandReference = (templatePath, componentRoot) => {
   const genericComponentPath = genericNamespace[1];
 
   return (
-    findExistingTemplateFile(
+    findExistingComponentTemplateFile(
       buildTemplateFileCandidates(componentRoot, genericComponentPath),
+      componentRoot,
     ) || resolveGroupedComponentTemplate(genericComponentPath, componentRoot)
   );
 };
@@ -614,9 +688,15 @@ const resolveTwigTemplateWithoutCache = (templatePath, fromDir, options) => {
     options.namespaces,
   );
   if (namespaced) {
-    const namespacedTemplate = findExistingTemplateFile(
-      buildTemplateFileCandidates(namespaced.root, namespaced.path),
-    );
+    const namespacedTemplate =
+      namespaced.namespace === 'components'
+        ? findExistingComponentTemplateFile(
+            buildTemplateFileCandidates(namespaced.root, namespaced.path),
+            namespaced.root,
+          )
+        : findExistingTemplateFile(
+            buildTemplateFileCandidates(namespaced.root, namespaced.path),
+          );
     if (namespacedTemplate) {
       return namespacedTemplate;
     }
@@ -915,6 +995,16 @@ export function emulsifyTwigModulePlugin(options) {
   const dependencyImporters = new Map();
 
   /**
+   * Twig entry modules transformed by this plugin instance.
+   *
+   * Structural component changes invalidate these modules because a new or
+   * removed directory can change the target of a shorthand reference.
+   *
+   * @type {Set<string>}
+   */
+  const transformedTwigModules = new Set();
+
+  /**
    * Remember that one imported Twig module depends on another Twig file.
    *
    * @param {string} dependency - Absolute dependency template path.
@@ -948,7 +1038,9 @@ export function emulsifyTwigModulePlugin(options) {
     buildStart() {
       compileCache.clear();
       resolutionCache.clear();
+      componentGroupRootsCache.clear();
       knownTwigFiles.clear();
+      transformedTwigModules.clear();
     },
     transform(...args) {
       const [, id] = args;
@@ -958,6 +1050,7 @@ export function emulsifyTwigModulePlugin(options) {
 
       const filePath = stripRequestQuery(id);
       const sourceFilePath = resolve(filePath);
+      transformedTwigModules.add(sourceFilePath);
       /** @type {Map<string, ReturnType<typeof compileTwigTemplate>>} */
       const compiledDependencyTemplates = new Map();
       /** @type {Map<string, Set<string>>} */
@@ -1106,6 +1199,7 @@ export function emulsifyTwigModulePlugin(options) {
                 compiledDependency.templateId,
                 compiledDependency.templateParams,
               )};
+              ${variableName}.method = 'emulsify';
             `,
           )
           .join('\n');
@@ -1153,9 +1247,21 @@ export function emulsifyTwigModulePlugin(options) {
           const Twig = factory();
           registerTwigExtensions(Twig);
           registerConfiguredTwigExtensions(Twig);
+          Twig.extend((TwigCore) => {
+            TwigCore.Templates.registerLoader(
+              'emulsify',
+              (location, params = {}) => {
+                const templateName = params.path || params.id || location;
+                throw new TwigCore.Error(
+                  'Unable to find template ' + templateName + '.',
+                );
+              },
+            );
+          });
 
           ${dependencyTemplateCode}
           const __emulsifyTemplate = ${compiled.code};
+          __emulsifyTemplate.method = 'emulsify';
           const __emulsifyIncludeTemplates = new Map();
           const __emulsifySourceTemplates = new Map();
           ${includeTemplateRegistrations}
@@ -1192,21 +1298,54 @@ export function emulsifyTwigModulePlugin(options) {
       }
     },
     handleHotUpdate({ file, server }) {
-      if (!file.endsWith('.twig')) {
+      const filePath = resolve(file);
+      const componentRoot = options.namespaces?.components
+        ? resolve(options.namespaces.components)
+        : null;
+      const cachedComponentRoots = componentRoot
+        ? componentGroupRootsCache.get(componentRoot)
+        : undefined;
+      let fileIsDirectory = false;
+
+      try {
+        fileIsDirectory = fs.statSync(filePath).isDirectory();
+      } catch {
+        // Removed paths cannot be inspected.
+      }
+
+      const componentDirectoryChanged =
+        !!componentRoot &&
+        isWithinRoot(componentRoot, filePath) &&
+        (fileIsDirectory || cachedComponentRoots?.includes(filePath));
+      if (componentDirectoryChanged) {
+        componentGroupRootsCache.delete(componentRoot);
+        resolutionCache.clear();
+        compileCache.clear();
+      }
+
+      if (!file.endsWith('.twig') && !componentDirectoryChanged) {
         return undefined;
       }
 
-      const filePath = resolve(file);
       const fileExists = safeExists(filePath);
       const knownFile = knownTwigFiles.has(filePath);
-      compileCache.delete(filePath);
       const importers = dependencyImporters.get(filePath);
-      if (!fileExists) {
+      const projectRoot = options.projectDir || options.root;
+      const projectPathChanged =
+        !!projectRoot &&
+        isWithinRoot(resolve(projectRoot), filePath) &&
+        fileExists !== knownFile;
+      const structuralChange = componentDirectoryChanged || projectPathChanged;
+
+      if (file.endsWith('.twig')) {
+        compileCache.delete(filePath);
+      }
+      if (!fileExists && file.endsWith('.twig')) {
         dependencyImporters.delete(filePath);
         knownTwigFiles.delete(filePath);
+        transformedTwigModules.delete(filePath);
       }
 
-      const projectRoot = options.projectDir || options.root;
       if (projectRoot && isWithinRoot(resolve(projectRoot), filePath)) {
         /**
          * Existing files only need entries for their own path and source
@@ -1220,26 +1359,47 @@ export function emulsifyTwigModulePlugin(options) {
         }
       }
 
-      if (!importers?.size) {
+      if (
+        componentRoot &&
+        isWithinRoot(componentRoot, filePath) &&
+        structuralChange
+      ) {
+        componentGroupRootsCache.delete(componentRoot);
+      }
+
+      if (structuralChange) {
+        compileCache.clear();
+      }
+
+      const affectedImporters = new Set(importers || []);
+      if (structuralChange) {
+        for (const transformedModule of transformedTwigModules) {
+          affectedImporters.add(transformedModule);
+        }
+      }
+
+      if (!affectedImporters.size) {
         return undefined;
       }
 
-      const modules = new Set(
-        server.moduleGraph.getModulesByFile(filePath) || [],
-      );
-      for (const importer of importers) {
+      const moduleGraph = server?.moduleGraph;
+      if (!moduleGraph?.getModulesByFile) {
+        return undefined;
+      }
+
+      const modules = new Set(moduleGraph.getModulesByFile(filePath) || []);
+      for (const importer of affectedImporters) {
         compileCache.delete(importer);
 
-        const importerModules =
-          server.moduleGraph.getModulesByFile(importer) || [];
+        const importerModules = moduleGraph.getModulesByFile(importer) || [];
 
         for (const module of importerModules) {
-          server.moduleGraph.invalidateModule(module);
+          moduleGraph.invalidateModule?.(module);
           modules.add(module);
         }
       }
 
-      return Array.from(modules);
+      return modules.size ? Array.from(modules) : undefined;
     },
   };
 }

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -238,7 +238,11 @@ Project-scoped component IDs are also supported. The namespace segment is the co
 {% include 'project_id:button' %}
 ```
 
-Both namespace paths and project-scoped IDs can resolve grouped component folders. For example, `@components/button/button.twig` and `project_id:button` can resolve `src/components/ui/button/button.twig` when components are organized under a grouping directory such as `ui`.
+Both namespace paths and project-scoped IDs can resolve grouped component folders at any depth. For example, `@components/atoms/text/headings/headings.twig` and `project_id:headings` can resolve `src/components/atoms/text/headings/headings.twig`.
+
+Exact configured namespace paths take precedence over shorthand lookup. Project-scoped shorthand checks a component directly under the configured component root first, then grouped directories in shallowest-first order with lexical ordering between directories at the same depth. If multiple grouped components use the same name, that deterministic order selects one; use an exact path such as `@components/atoms/text/headings/headings.twig` to remove the ambiguity. Recursive lookup remains confined to the configured component root and does not follow directory symlinks outside it.
+
+The project-scope prefix is currently shorthand syntax rather than strict `project.machineName` validation: when the segment before `:` is not a configured Twig namespace, Core searches component roots using the segment after `:`. Prefer the configured machine name for portable project templates, and prefer exact namespace paths when a component name is duplicated.
 
 The runtime supports explicit variables, `with_context`, `ignore_missing`, and ordered template candidates:
 

--- a/scripts/release-fixtures.js
+++ b/scripts/release-fixtures.js
@@ -143,6 +143,10 @@ const releaseFixtures = [
         pattern: '.out/storybook-assets/card.stories-*.js',
         strings: ['Twig fixture', 'React fixture'],
       },
+      {
+        pattern: '.out/storybook-assets/*.js',
+        strings: ['data-nested-project-alias'],
+      },
     ],
   },
   {

--- a/src/storybook/twig/resolver.js
+++ b/src/storybook/twig/resolver.js
@@ -91,9 +91,26 @@ function findGroupedComponentEntry(map, candidates, env) {
 
   for (const { rootRel, suffix } of groupedComponentSuffixes(candidates, env)) {
     const rootPrefix = `${rootRel}/`;
-    const match = entries.find(
-      ([key]) => key.startsWith(rootPrefix) && key.endsWith(suffix),
-    );
+    const matches = entries
+      .filter(([key]) => key.startsWith(rootPrefix) && key.endsWith(suffix))
+      .sort(([leftKey], [rightKey]) => {
+        const leftGroupingPath = leftKey.slice(
+          rootPrefix.length,
+          -suffix.length,
+        );
+        const rightGroupingPath = rightKey.slice(
+          rootPrefix.length,
+          -suffix.length,
+        );
+        const leftDepth = leftGroupingPath.split('/').filter(Boolean).length;
+        const rightDepth = rightGroupingPath.split('/').filter(Boolean).length;
+
+        if (leftDepth !== rightDepth) {
+          return leftDepth - rightDepth;
+        }
+        return leftKey === rightKey ? 0 : leftKey < rightKey ? -1 : 1;
+      });
+    const match = matches[0];
     if (match) {
       return { key: match[0], value: match[1] };
     }

--- a/src/storybook/twig/resolver.test.js
+++ b/src/storybook/twig/resolver.test.js
@@ -119,12 +119,13 @@ describe('Storybook Twig resolver', () => {
     const resolver = createTwigResolver({
       env: createEnv(),
       modules: {
-        '/src/components/ui/heading/heading.twig': {
+        '/src/components/atoms/text/heading/heading.twig': {
           default: headingTemplate,
         },
       },
       sources: {
-        '/src/components/ui/heading/heading.twig': '<h2>{{ heading }}</h2>',
+        '/src/components/atoms/text/heading/heading.twig':
+          '<h2>{{ heading }}</h2>',
       },
     });
 
@@ -150,6 +151,28 @@ describe('Storybook Twig resolver', () => {
     });
 
     expect(resolver.resolveTemplate('whisk:heading')).toBe(exactTemplate);
+  });
+
+  it('resolves duplicate grouped component names deterministically', () => {
+    const deeperTemplate = jest.fn(() => '<h2>Deeper</h2>');
+    const betaTemplate = jest.fn(() => '<h2>Beta</h2>');
+    const alphaTemplate = jest.fn(() => '<h2>Alpha</h2>');
+    const resolver = createTwigResolver({
+      env: createEnv(),
+      modules: {
+        '/src/components/aardvark/text/heading/heading.twig': {
+          default: deeperTemplate,
+        },
+        '/src/components/beta/heading/heading.twig': {
+          default: betaTemplate,
+        },
+        '/src/components/alpha/heading/heading.twig': {
+          default: alphaTemplate,
+        },
+      },
+    });
+
+    expect(resolver.resolveTemplate('whisk:heading')).toBe(alphaTemplate);
   });
 
   it('loads lazy raw Twig source once and caches it for later sync reads', async () => {


### PR DESCRIPTION
**Summary**

Fixes inconsistent compile-time resolution of project-scoped Twig component references when components are nested beneath multiple grouping directories.

The compile-time resolver now:

- Recursively searches grouping directories within the configured component root.
- Preserves exact namespace, direct-root, and one-level resolution precedence.
- Uses deterministic shallowest-first and lexical ordering for ambiguous shorthand references.
- Caches recursive traversal and invalidates affected caches and modules when HMR adds or removes component paths.
- Safely skips unreadable directories and prevents traversal outside the component root.
- Uses a browser-safe missing-template loader so unresolved references do not fall through to Twig.js’s filesystem loader.

Storybook’s runtime resolver now uses the same deterministic ambiguity behavior.

**Related issue(s)**

No linked issue. This problem was discovered while using project-scoped Twig component references in a client project with components nested under paths such as `src/components/atoms/text/headings`.

**Checklist**

- [x] Tests run and results noted
- [x] Documentation impact considered
- [x] Migration or backward compatibility impact considered
- [x] Accessibility impact considered
- [x] Release fixture impact considered

**Notes**

Validation completed:

- `npm run lint`
- `npm test -- --runInBand` — 47 suites, 306 tests, and 11 snapshots passed
- `npm run fixtures:release` — all seven release fixtures passed
- `npm run storybook-build`
- Installed-package import smoke passed

The mixed Storybook release fixture now includes the reported nested structure:

`src/components/atoms/text/headings/headings.twig`

and resolves it through:

`{% include 'mixed_storybook:headings' %}`

No migration is required. Exact namespace paths continue to take precedence, followed by direct-root components and grouped shorthand matches. Duplicate shorthand names resolve by the shallowest directory and then lexical order; exact references such as `@components/atoms/text/headings/headings.twig` should be used to remove ambiguity.

The project-scope prefix remains shorthand syntax rather than strict `project.machineName` validation when it does not match a configured Twig namespace.

There is no accessibility impact because this changes template resolution and build behavior without altering user-interface interactions.

The conventional `fix(twig):` commit will be classified as a patch by semantic-release, producing version 4.2.1 from 4.2.0 after merge.