### PR TITLE
fix(assets): emit Twig templates whose names begin with an underscore

### DIFF
--- a/config/vite/plugins/assets/copy-files.test.js
+++ b/config/vite/plugins/assets/copy-files.test.js
@@ -58,8 +58,10 @@ describe('source copy plugins', () => {
     runCopyPlugins(structure, outDir);
 
     expect(existsSync(join(outDir, 'components/card/card.twig'))).toBe(true);
+    // An underscored Twig template is still included at render time, so it has to
+    // be emitted. Only stylesheets treat the prefix as "no output of its own".
     expect(existsSync(join(outDir, 'components/card/_partial.twig'))).toBe(
-      false,
+      true,
     );
     expect(existsSync(join(outDir, 'components/card/card.component.yml'))).toBe(
       true,
@@ -117,15 +119,16 @@ describe('source copy plugins', () => {
 
     expect(existsSync(join(outDir, 'components/card/card.twig'))).toBe(true);
     expect(existsSync(join(outDir, 'components/card/_partial.twig'))).toBe(
-      false,
+      true,
     );
     expect(existsSync(join(outDir, 'components/card/card.component.yml'))).toBe(
       true,
     );
     expect(existsSync(join(outDir, 'components/card/image.png'))).toBe(true);
     expect(existsSync(join(outDir, 'foundation/icons/icon.svg'))).toBe(true);
+    // Emitted from a named structure root too, not only from component roots.
     expect(existsSync(join(outDir, 'foundation/icons/_partial.twig'))).toBe(
-      false,
+      true,
     );
     expect(
       existsSync(join(outDir, 'foundation/icons/icon.component.json')),
@@ -213,9 +216,10 @@ describe('source copy plugins', () => {
       }
     });
 
-    it('leaves partials and compiled entries out of the watch set', () => {
-      // Partials are not copied, and Rollup already watches the SCSS it compiles.
-      // Registering either here would buy a rebuild that copies nothing.
+    it('watches an underscored template and leaves compiled entries alone', () => {
+      // The plan drives both hooks, so a template that is now copied is also now
+      // watched — saving it has to update dist/ like any other template. SCSS
+      // stays out because Rollup already watches what it compiles.
       const { structure, outDir } = scaffold();
       const watched = [
         ...watchedBy(copyTwigFilesPlugin({ structure }), {
@@ -228,9 +232,7 @@ describe('source copy plugins', () => {
         }),
       ];
 
-      expect(watched.some((path) => path.endsWith('_partial.twig'))).toBe(
-        false,
-      );
+      expect(watched.some((path) => path.endsWith('_partial.twig'))).toBe(true);
       expect(watched.some((path) => path.endsWith('card.scss'))).toBe(false);
     });
 
@@ -278,8 +280,49 @@ describe('source copy plugins', () => {
       expect(existsSync(join(outDir, 'components/card/card.twig'))).toBe(true);
       expect(existsSync(join(outDir, 'components/card/icon.svg'))).toBe(true);
       expect(existsSync(join(outDir, 'components/card/_partial.twig'))).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('underscored templates', () => {
+    it('emits an underscored template so a runtime include can resolve it', () => {
+      // The bug this covers: `{% include '@components/card/_inner.twig' %}` is
+      // resolved by Twig at render time against the emitted tree, so a template
+      // left out of dist/ is a 404 on the rendered page. Nothing about the
+      // filename makes it inlinable the way a Sass partial is.
+      projectDir = makeTempProject();
+      const componentDir = join(projectDir, 'src/components/card');
+      const outDir = join(projectDir, 'dist');
+      mkdirSync(componentDir, { recursive: true });
+      writeFileSync(
+        join(componentDir, 'card.twig'),
+        '<div>{% include "@components/card/_inner.twig" %}</div>',
+      );
+      writeFileSync(join(componentDir, '_inner.twig'), '<span></span>');
+      writeFileSync(join(componentDir, '_inner.scss'), '.inner {}');
+
+      runCopyPlugins(resolveProjectStructure(makeEnv(projectDir)), outDir);
+
+      expect(existsSync(join(outDir, 'components/card/_inner.twig'))).toBe(
+        true,
+      );
+      // The Sass partial keeps its exclusion; it has no output of its own.
+      expect(existsSync(join(outDir, 'components/card/_inner.scss'))).toBe(
         false,
       );
+    });
+
+    it('emits an underscored template from a global root', () => {
+      projectDir = makeTempProject();
+      const globalDir = join(projectDir, 'src/layout');
+      const outDir = join(projectDir, 'dist');
+      mkdirSync(globalDir, { recursive: true });
+      writeFileSync(join(globalDir, '_grid.twig'), '<div class="grid"></div>');
+
+      runCopyPlugins(resolveProjectStructure(makeEnv(projectDir)), outDir);
+
+      expect(existsSync(join(outDir, 'global/layout/_grid.twig'))).toBe(true);
     });
   });
 });

--- a/config/vite/plugins/assets/copy-twig-files.js
+++ b/config/vite/plugins/assets/copy-twig-files.js
@@ -17,10 +17,6 @@ import {
   isComponentMetadataFile,
 } from './source-file-index.js';
 
-/** Determine whether a Twig file is a partial (filename starts with `_`). */
-const isPartial = (filePath) =>
-  (filePath.split('/')?.pop() || '').trim().startsWith('_');
-
 /**
  * Copy Twig templates and component metadata to `dist/`.
  *
@@ -51,11 +47,18 @@ export function copyTwigFilesPlugin({
 
     plan = [];
 
+    // A leading underscore excludes a stylesheet from compilation, because a Sass
+    // partial is inlined into whatever imports it and has no output of its own.
+    // Twig has no equivalent: `{% include %}` and `{% embed %}` resolve at render
+    // time against the emitted tree, so an underscored template is a file the site
+    // still has to find. Skipping those left the include unresolvable at runtime.
     for (const file of sourceFileIndex.componentFiles()) {
-      const isTwig = file.absPath.endsWith('.twig');
-
-      if (!isTwig && !isComponentMetadataFile(file.absPath)) continue;
-      if (isTwig && isPartial(file.relPath)) continue;
+      if (
+        !file.absPath.endsWith('.twig') &&
+        !isComponentMetadataFile(file.absPath)
+      ) {
+        continue;
+      }
 
       plan.push({
         absPath: file.absPath,
@@ -65,7 +68,6 @@ export function copyTwigFilesPlugin({
 
     for (const file of sourceFileIndex.globalFiles()) {
       if (!file.absPath.endsWith('.twig')) continue;
-      if (isPartial(file.relPath)) continue;
 
       plan.push({
         absPath: file.absPath,

--- a/docs/develop-reporter.md
+++ b/docs/develop-reporter.md
@@ -135,9 +135,10 @@ until an unrelated stylesheet changed. Storybook renders Twig through its own
 pipeline and looked correct throughout, which made the stale copy visible only to
 whatever consumes `dist/`.
 
-Two things deliberately do not trigger a Vite rebuild. Story files are Storybook's
-to watch, and Twig partials are not copied — a partial reached from a story's Twig
-import is already watched by the Twig module plugin.
+Story files deliberately do not trigger a Vite rebuild; Storybook watches those
+itself. Every Twig template does, including ones whose names begin with an
+underscore — Twig resolves `{% include %}` at render time against the emitted tree,
+so those are files the site still has to find.
 
 Adding a _new_ file is different from editing one. The entry map and the source
 index are both resolved once at config time, and Rollup cannot take new inputs


### PR DESCRIPTION
`copyTwigFilesPlugin` skipped any Twig file whose basename started with `_`, treating the prefix the way `entries.js` treats it for stylesheets. The two are not the same convention.

A leading underscore on a Sass file means the file has no output of its own: it is inlined into whatever imports it, so compiling it separately would emit a duplicate. Twig has no equivalent. `{% include %}` and `{% embed %}` are resolved by Twig at render time against the emitted tree, so an underscored template is a file the site still has to find. Leaving it out of `dist/` turned every include of one into a runtime failure on the rendered page, while Storybook — which resolves Twig through its own pipeline against the source tree — kept rendering correctly.

Both loops now emit every `.twig` file they encounter, from component roots and global roots alike. The stylesheet exclusion in `entries.js` is untouched and still correct.

Because the copy plan drives `addWatchFile` as well as the copy, these templates are now watched too, so saving one updates `dist/` like any other template.

Verified against a real build: `_card-inner.twig` and `src/layout/_grid.twig` both land in `dist/`, and no `_*.scss` is emitted as a file.

`emulsify-inspect-components` still reports only non-partial templates, which is a separate and deliberate distinction — a partial is not a component.

**Summary**

_Describe the change._

**Related issue(s)**

_Link originating issues or feature pull requests. If no issue exists, briefly
explain how and why the work entered this pull request._

<!--
Release pull requests must follow docs/release-review.md. Include distinct
sections for user-facing additions, compatibility and migration impact,
internal architecture and performance changes, public API and package-export
changes, known limitations, exact release evidence, outstanding checks, and
originating work. Record evidence or a not-applicable reason for every review
track.
-->

**Checklist**

- [ ] Tests run and results noted
- [ ] Documentation impact considered
- [ ] Migration or backward compatibility impact considered
- [ ] Accessibility impact considered
- [ ] Release fixture impact considered
- [ ] Release pull request only: required description sections and all tracks
      in [the release-review checklist](https://github.com/emulsify-ds/emulsify-core/blob/develop/docs/release-review.md)
      completed

**Notes**

_Add context for reviewers, if needed._
